### PR TITLE
allow facility_code to be longer

### DIFF
--- a/tracpro/contacts/migrations/0004_auto_20150324_1024.py
+++ b/tracpro/contacts/migrations/0004_auto_20150324_1024.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0003_auto_20150224_1245'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contact',
+            name='facility_code',
+            field=models.CharField(help_text='Facility code for this contact', max_length=160, null=True, verbose_name='Facility Code', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -30,7 +30,7 @@ class Contact(models.Model):
 
     group = models.ForeignKey(Group, null=True, verbose_name=_("Reporter group"), related_name='contacts')
 
-    facility_code = models.CharField(max_length=16, verbose_name=_("Facility Code"), null=True, blank=True,
+    facility_code = models.CharField(max_length=160, verbose_name=_("Facility Code"), null=True, blank=True,
                                      help_text=_("Facility code for this contact"))
 
     language = models.CharField(max_length=3, verbose_name=_("Language"), null=True, blank=True,

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -12,6 +12,7 @@ from dash.orgs.models import Org
 from dash.utils import get_cacheable, get_month_range
 from dateutil.relativedelta import relativedelta
 from decimal import Decimal
+from decimal import InvalidOperation
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -511,7 +512,7 @@ class Answer(models.Model):
                     value = Decimal(answer.value)
                     total += value
                     count += 1
-                except ValueError:
+                except (ValueError, InvalidOperation):
                     continue
 
         return float(total / count) if count else 0

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -535,7 +535,7 @@ class Answer(models.Model):
                     if value > value_max or value_max is None:
                         value_max = value
                     values.append(value)
-                except ValueError:
+                except (ValueError, InvalidOperation):
                     continue
 
         if not values:


### PR DESCRIPTION
16 chars seems pretty small. 

in many use cases, there may not be a formal coding system for enumerating facilites -- with a longer char limit on this field, tracpro can accommodate facility names in the `facility_code` field