### PR TITLE
Reworked run fetching task for latest RapidPro changes 

### DIFF
--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -55,7 +55,10 @@ class OrgExtCRUDL(OrgCRUDL):
         def get_last_flow_run_fetch(self, obj):
             result = obj.get_task_result(constants.TaskType.fetch_runs)
             if result:
-                return format_datetime(ms_to_datetime(result['time']))
+                return "%s (%d fetched)" % (
+                    format_datetime(ms_to_datetime(result['time'])),
+                    result.get('counts', {}).get('fetched', 0)
+                )
             else:
                 return None
 

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -454,17 +454,6 @@ class Response(models.Model):
 
         return last_value_on if last_value_on else run.created_on
 
-    @classmethod
-    def get_update_required(cls, org):
-        """
-        Gets incomplete responses to the latest pollruns of all polls so that they can be updated
-        """
-        # get polls with the latest pollrun id for each
-        polls = Poll.get_all(org).annotate(latest_pollrun_id=models.Max('pollruns'))
-        latest_pollruns = [p.latest_pollrun_id for p in polls if p.latest_pollrun_id]
-
-        return Response.objects.filter(pollrun__in=latest_pollruns, is_active=True).exclude(status=RESPONSE_COMPLETE)
-
 
 class Answer(models.Model):
     """

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -7,11 +7,12 @@ from djcelery_transactions import task
 from django_redis import get_redis_connection
 from temba.utils import parse_iso8601, format_iso8601
 
-from dash.utils import datetime_to_ms, chunks
+from dash.utils import datetime_to_ms
 from dash.orgs.models import Org
 
 logger = get_task_logger(__name__)
 
+FETCH_ALL_RUNS_LOCK = 'task:fetch_all_runs'
 LAST_FETCHED_RUN_TIME_KEY = 'org:%d:last_fetched_run_time'
 
 
@@ -20,102 +21,59 @@ def fetch_all_runs():
     """
     Fetches flow runs for all orgs
     """
-    logger.info("Starting flow run fetch for all orgs...")
+    r = get_redis_connection()
 
-    for org in Org.objects.filter(is_active=True).prefetch_related('polls'):
-        fetch_org_runs(org)
+    # only do this if we aren't already running so we don't get backed up
+    if not r.get(FETCH_ALL_RUNS_LOCK):
+        with r.lock(FETCH_ALL_RUNS_LOCK, timeout=600):
+            logger.info("Starting flow run fetch for all orgs...")
+
+            for org in Org.objects.filter(is_active=True).prefetch_related('polls'):
+                fetch_org_runs(org)
+    else:
+        logger.warn("Skipping run fetch as it is already running")
 
 
 def fetch_org_runs(org):
     """
-    Fetches flow runs for the given org
+    Fetches new and modified flow runs for the given org and creates/updates poll responses
     """
     from tracpro.orgs_ext.constants import TaskType
-
-    fetch_org_new_runs(org)
-    fetch_org_updated_runs(org)
-
-    task_result = dict(time=datetime_to_ms(timezone.now()))
-    org.set_task_result(TaskType.fetch_runs, task_result)
-
-
-def fetch_org_new_runs(org):
     from tracpro.polls.models import Poll, Response
 
     client = org.get_temba_client()
     r = get_redis_connection()
     last_time_key = LAST_FETCHED_RUN_TIME_KEY % org.pk
-
-    newest_run = None
     last_time = r.get(last_time_key)
+
     if last_time is not None:
         last_time = parse_iso8601(last_time)
     else:
         newest_run = Response.objects.filter(pollrun__poll__org=org).order_by('-created_on').first()
         last_time = newest_run.created_on if newest_run else None
 
-    polls_by_flow_uuids = {p.flow_uuid: p for p in Poll.get_all(org)}
+    until = timezone.now()
 
-    runs = client.get_runs(flows=polls_by_flow_uuids.keys(), after=last_time)
-
-    if runs:
-        # because the Temba API compares after dates with gte, oldest run will be usually be a duplicate
-        oldest_run = runs[len(runs) - 1]
-        if Response.objects.filter(flow_run_id=oldest_run.id).exists():
-            runs = runs[0:-1]
-
-    logger.info("Fetched %d new runs for org #%d (after=%s)"
-                % (len(runs), org.id, format_iso8601(last_time) if last_time else 'Never'))
-
-    if runs:
-        newest_run = runs[0]
+    total_runs = 0
+    for poll in Poll.get_all(org):
+        poll_runs = client.get_runs(flows=[poll.flow_uuid], after=last_time, before=until)
+        total_runs += len(poll_runs)
 
         # convert flow runs into poll responses
-        for run in runs:
-            # if this rapidpro flow has not been imported into the org, go to the next one in the loop
-            if run.flow not in polls_by_flow_uuids:
-                logger.error("Unable to track new response because flow %s has not been imported" % (run.flow))
+        for run in poll_runs:
+            try:
+                Response.from_run(org, run, poll=poll)
+            except ValueError, e:
+                logger.error("Unable to save run #%d due to error: %s" % (run.id, e.message))
                 continue
 
-            else:
-                poll = polls_by_flow_uuids[run.flow]
-                try:
-                    Response.from_run(org, run, poll=poll)
-                except ValueError, e:
-                    logger.error("Unable to save run #%d due to error: %s" % (run.id, e.message))
-                    continue
+    logger.info("Fetched %d new and updated runs for org #%d (since=%s)"
+                % (total_runs, org.id, format_iso8601(last_time) if last_time else 'Never'))
 
-    if newest_run:
-        r.set(last_time_key, format_iso8601(newest_run.created_on))
+    task_result = dict(time=datetime_to_ms(timezone.now()), counts=dict(fetched=total_runs))
+    org.set_task_result(TaskType.fetch_runs, task_result)
 
-
-def fetch_org_updated_runs(org):
-    """
-    Fetches updated runs for incomplete responses
-    """
-    from tracpro.polls.models import Poll, Response
-
-    client = org.get_temba_client()
-
-    incomplete_responses = Response.get_update_required(org)
-
-    # Not yet sure what the optimum can be in order to make the smallest number of requests.
-    max_number_fetchable_runs = 50
-
-    if incomplete_responses:
-        runs = []
-        for resp_chunk in chunks(list(incomplete_responses), max_number_fetchable_runs):
-            runs += client.get_runs(ids=[r.flow_run_id for r in resp_chunk])
-
-        logger.info("Fetched %d runs for incomplete responses" % len(runs))
-
-        polls_by_flow_uuids = {p.flow_uuid: p for p in Poll.get_all(org)}
-
-        for run in runs:
-            poll = polls_by_flow_uuids[run.flow]
-            Response.from_run(org, run, poll=poll)
-    else:
-        logger.info("No incomplete responses to update")
+    r.set(last_time_key, format_iso8601(until))
 
 
 @task

--- a/tracpro/polls/tests.py
+++ b/tracpro/polls/tests.py
@@ -54,39 +54,6 @@ class PollTest(TracProDataTest):
         # existing poll that was inactive should now be active
         self.assertTrue(Poll.objects.get(flow_uuid='F-001').is_active)
 
-    def test_get_update_required(self):
-        # no pollruns means no responses to update
-        self.assertEqual(Response.get_update_required(self.unicef).count(), 0)
-
-        # create pollrun but no responses yet
-        pollrun1 = PollRun.get_or_create_non_regional(self.unicef, self.poll1, for_date=self.datetime(2014, 1, 1))
-
-        self.assertEqual(Response.get_update_required(self.unicef).count(), 0)
-
-        # add an empty, a partial and a complete response
-        response1 = Response.objects.create(
-            flow_run_id=123, pollrun=pollrun1, contact=self.contact1,
-            created_on=timezone.now(), updated_on=timezone.now(),
-            status=RESPONSE_EMPTY)
-        response2 = Response.objects.create(
-            flow_run_id=234, pollrun=pollrun1, contact=self.contact2,
-            created_on=timezone.now(), updated_on=timezone.now(),
-            status=RESPONSE_PARTIAL)
-        Response.objects.create(
-            flow_run_id=345, pollrun=pollrun1, contact=self.contact3,
-            created_on=timezone.now(), updated_on=timezone.now(),
-            status=RESPONSE_COMPLETE)
-
-        self.assertEqual(list(Response.get_update_required(self.unicef).order_by('pk')), [response1, response2])
-
-        # create newer pollrun with an incomplete response
-        pollrun2 = PollRun.get_or_create_non_regional(self.unicef, self.poll1, for_date=self.datetime(2014, 1, 2))
-        response3 = Response.objects.create(flow_run_id=456, pollrun=pollrun2, contact=self.contact1,
-                                            created_on=timezone.now(), updated_on=timezone.now(), status=RESPONSE_EMPTY)
-
-        # shouldn't include any responses from older pollrun
-        self.assertEqual(list(Response.get_update_required(self.unicef)), [response3])
-
     def test_get_questions(self):
         self.assertEqual(list(self.poll1.get_questions()), [self.poll1_question1, self.poll1_question2])
         self.assertEqual(list(self.poll2.get_questions()), [self.poll2_question1])


### PR DESCRIPTION
which return runs using modified_on rather than created_on. Also added lock to prevent task from overlapping.