### PR TITLE
Hierarchical region permissions in `baseline` app

### DIFF
--- a/tracpro/baseline/tests/test_models.py
+++ b/tracpro/baseline/tests/test_models.py
@@ -86,7 +86,7 @@ class BaselineTermTest(TracProDataTest):
 
     def test_baseline_all_regions(self):
         """ Answers were 10, 20 and 30: Total should be 10 + 20 + 30 = 60 """
-        baseline_dict, dates = self.baselineterm.get_baseline(region=None)
+        baseline_dict, dates = self.baselineterm.get_baseline(regions=None)
 
         self.assertEqual(len(baseline_dict), 2)  # Two regions, two sets of baseline values
         # Two answers, 10 + 20 = 30
@@ -100,7 +100,7 @@ class BaselineTermTest(TracProDataTest):
 
     def test_baseline_single_region(self):
         """ Answers were 10 and 20 for region1 """
-        baseline_dict, dates = self.baselineterm.get_baseline(region=self.region1)
+        baseline_dict, dates = self.baselineterm.get_baseline(regions=[self.region1])
 
         self.assertEqual(len(baseline_dict), 1)  # One regions, one baseline
         # Two answers sum = 10 + 20 = 30
@@ -128,7 +128,7 @@ class BaselineTermTest(TracProDataTest):
                 submitted_on=self.end_date,
                 category=u'')
 
-        baseline_dict, dates = self.baselineterm.get_baseline(region=self.region1)
+        baseline_dict, dates = self.baselineterm.get_baseline(regions=[self.region1])
 
         self.assertEqual(len(baseline_dict), 1)  # One regions, one baseline
         # Two sets of baseline answers
@@ -143,7 +143,7 @@ class BaselineTermTest(TracProDataTest):
         Region 1 values [9, 8] + [15, 10]  = [24, 18]
         Region 2 values [25, 20]
         """
-        follow_ups, dates = self.baselineterm.get_follow_up(region=None)
+        follow_ups, dates = self.baselineterm.get_follow_up(regions=None)
 
         self.assertEqual(len(dates), 3)  # 3 dates
         self.assertEqual(len(follow_ups), 2)  # 2 regions for the follow up dictionary
@@ -161,7 +161,7 @@ class BaselineTermTest(TracProDataTest):
         Region 1 values [9, 8] + [15, 10]  = [24, 18]
         Region 2 values [25, 20]
         """
-        follow_ups, dates = self.baselineterm.get_follow_up(region=self.region2)
+        follow_ups, dates = self.baselineterm.get_follow_up(regions=[self.region2])
 
         self.assertEqual(len(dates), 3)  # 3 dates
         self.assertEqual(len(follow_ups), 1)  # One region for the follow up dictionary

--- a/tracpro/baseline/tests/test_views.py
+++ b/tracpro/baseline/tests/test_views.py
@@ -148,8 +148,8 @@ class TestBaselineTermCRUDL(TracProDataTest):
             fetch_redirect_response=False)
 
         # Check new spoofed data created successfully
-        # 3 PollRuns, Responses and Answers
+        # 1 PollRun, and 3 each of Responses and Answers
         # for 1 Baseline Date and 2 Follow Up Dates
-        self.assertEqual(PollRun.objects.all().count(), 3)
+        self.assertEqual(PollRun.objects.all().count(), 1)
         self.assertEqual(Response.objects.all().count(), 3)
         self.assertEqual(Answer.objects.all().count(), 3)

--- a/tracpro/baseline/views.py
+++ b/tracpro/baseline/views.py
@@ -126,9 +126,8 @@ class BaselineTermCRUDL(SmartCRUDL):
 
         def create_baseline(self, poll, date, contacts, baseline_question, baseline_minimum, baseline_maximum):
             baseline_datetime = datetime.combine(date, datetime.utcnow().time().replace(tzinfo=pytz.utc))
-            baseline_pollrun = PollRun.objects.create(
-                poll=poll, region=None,
-                conducted_on=baseline_datetime)
+            baseline_pollrun = PollRun.objects.get_or_create_universal(
+                poll=poll, conducted_on=baseline_datetime)
             for contact in contacts:
                 # Create a Response AKA FlowRun for each contact for Baseline
                 response = Response.objects.create(
@@ -165,9 +164,8 @@ class BaselineTermCRUDL(SmartCRUDL):
                     self.create_baseline(baseline_question.poll, follow_up_date, contacts,
                                          baseline_question, baseline_minimum, baseline_maximum)
                 follow_up_datetime = datetime.combine(follow_up_date, datetime.utcnow().time().replace(tzinfo=pytz.utc))
-                follow_up_pollrun = PollRun.objects.create(
-                    poll=follow_up_question.poll, region=None,
-                    conducted_on=follow_up_datetime)
+                follow_up_pollrun = PollRun.objects.get_or_create_universal(
+                    poll=follow_up_question.poll, conducted_on=follow_up_datetime)
                 for contact in contacts:
                     # Create a Response AKA FlowRun for each contact for Follow Up
                     response = Response.objects.create(

--- a/tracpro/baseline/views.py
+++ b/tracpro/baseline/views.py
@@ -73,11 +73,8 @@ class BaselineTermCRUDL(SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super(BaselineTermCRUDL.Read, self).get_context_data(**kwargs)
 
-            region = self.request.region
-
-            baseline_dict, baseline_dates = self.object.get_baseline(region=region)
-
-            follow_ups, dates = self.object.get_follow_up(region=region)
+            baseline_dict, baseline_dates = self.object.get_baseline(self.request.data_regions)
+            follow_ups, dates = self.object.get_follow_up(self.request.data_regions)
 
             # Create a list of all dates for this poll
             # Example: date_list =  ['09/01', '09/02', '09/03', ...]


### PR DESCRIPTION
This also fixes a small bug wherein `PollRun.pollrun_type` is not being set on spoof data.

When merged, we'll want to set the `pollrun_type` of such items:

```
from tracpro.polls.models import PollRun
PollRun.objects.filter(region=None, pollrun_type="").update(pollrun_type=PollRun.TYPE_UNIVERSAL)
```