### PR TITLE
Baseline modifications

### DIFF
--- a/tracpro/baseline/migrations/0004_auto_20150910_2018.py
+++ b/tracpro/baseline/migrations/0004_auto_20150910_2018.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('baseline', '0003_auto_20150910_1814'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='baselineterm',
+            name='end_date',
+            field=models.DateField(),
+        ),
+        migrations.AlterField(
+            model_name='baselineterm',
+            name='start_date',
+            field=models.DateField(),
+        ),
+    ]

--- a/tracpro/baseline/models.py
+++ b/tracpro/baseline/models.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import datetime
 
 import pytz
@@ -80,12 +79,12 @@ class BaselineTerm(models.Model):
             answers = answers.filter(response__contact__region__in=regions)
 
         # Separate out baseline values per region
-        region_answers = defaultdict(dict)
+        region_answers = {}
         dates = []
         for region_name in set(a.region_name.encode('ascii') for a in answers):
             answers_by_region = answers.filter(region_name=region_name)
             answer_sums, dates = answers_by_region.numeric_sum_group_by_date()
-            region_answers[region_name]["values"] = answer_sums
+            region_answers[region_name] = {'values': answer_sums}
         return region_answers, dates
 
     def get_follow_up(self, regions):
@@ -96,10 +95,10 @@ class BaselineTerm(models.Model):
         # a dict of values and dates per Region
         # ex.
         # { 'Kumpala': {'values': [35,...], 'dates': [datetime.date(2015, 8, 12),...]} }
-        region_answers = defaultdict(dict)
+        region_answers = {}
         dates = []
         for region_name in set(a.region_name.encode('ascii') for a in answers):
             answers_by_region = answers.filter(region_name=region_name)
             answer_sums, dates = answers_by_region.numeric_sum_group_by_date()
-            region_answers[region_name]["values"] = answer_sums
+            region_answers[region_name] = {'values': answer_sums}
         return region_answers, dates

--- a/tracpro/baseline/models.py
+++ b/tracpro/baseline/models.py
@@ -24,8 +24,8 @@ class BaselineTerm(models.Model):
         "Organization"), related_name="baseline_terms")
     name = models.CharField(max_length=255, help_text=_(
         "For example: 2015 Term 3 Attendance for P3 Girls"))
-    start_date = models.DateTimeField()
-    end_date = models.DateTimeField()
+    start_date = models.DateField()
+    end_date = models.DateField()
 
     baseline_poll = models.ForeignKey(Poll, related_name="baseline_terms")
     baseline_question = ChainedForeignKey(

--- a/tracpro/baseline/tests/test_views.py
+++ b/tracpro/baseline/tests/test_views.py
@@ -150,8 +150,8 @@ class TestBaselineTermCRUDL(TracProDataTest):
             fetch_redirect_response=False)
 
         # Check new spoofed data created successfully
-        # 1 PollRun, and 3 each of Responses and Answers
+        # 3 PollRuns, Responses, and Answers
         # for 1 Baseline Date and 2 Follow Up Dates
-        self.assertEqual(PollRun.objects.all().count(), 1)
+        self.assertEqual(PollRun.objects.all().count(), 3)
         self.assertEqual(Response.objects.all().count(), 3)
         self.assertEqual(Answer.objects.all().count(), 3)

--- a/tracpro/baseline/tests/test_views.py
+++ b/tracpro/baseline/tests/test_views.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.core.urlresolvers import reverse
 
 from tracpro.test.cases import TracProDataTest
@@ -19,8 +21,8 @@ class TestBaselineTermCRUDL(TracProDataTest):
         self.baselineterm = BaselineTerm.objects.create(
             name='Baseline Term SetUp',
             org=self.org,
-            start_date='2015-05-01',
-            end_date='2015-05-10',
+            start_date=datetime.date(2015, 5, 1),
+            end_date=datetime.date(2015, 5, 1),
             baseline_poll=self.poll1,
             baseline_question=self.poll1_question1,
             follow_up_poll=self.poll1,
@@ -30,8 +32,8 @@ class TestBaselineTermCRUDL(TracProDataTest):
         self.data = {
             'name': 'Test Baseline Term',
             'org': self.org.pk,
-            'start_date': '2015-05-01',
-            'end_date': '2015-05-10',
+            'start_date': 'May 1, 2015',
+            'end_date': 'May 1, 2015',
             'baseline_poll': self.poll1.pk,
             'baseline_question': self.poll1_question1.pk,
             'follow_up_poll': self.poll1.pk,

--- a/tracpro/baseline/views.py
+++ b/tracpro/baseline/views.py
@@ -126,7 +126,7 @@ class BaselineTermCRUDL(SmartCRUDL):
 
         def create_baseline(self, poll, date, contacts, baseline_question, baseline_minimum, baseline_maximum):
             baseline_datetime = datetime.combine(date, datetime.utcnow().time().replace(tzinfo=pytz.utc))
-            baseline_pollrun = PollRun.objects.get_or_create_universal(
+            baseline_pollrun = PollRun.objects.create_spoofed(
                 poll=poll, conducted_on=baseline_datetime)
             for contact in contacts:
                 # Create a Response AKA FlowRun for each contact for Baseline
@@ -164,7 +164,7 @@ class BaselineTermCRUDL(SmartCRUDL):
                     self.create_baseline(baseline_question.poll, follow_up_date, contacts,
                                          baseline_question, baseline_minimum, baseline_maximum)
                 follow_up_datetime = datetime.combine(follow_up_date, datetime.utcnow().time().replace(tzinfo=pytz.utc))
-                follow_up_pollrun = PollRun.objects.get_or_create_universal(
+                follow_up_pollrun = PollRun.objects.create_spoofed(
                     poll=follow_up_question.poll, conducted_on=follow_up_datetime)
                 for contact in contacts:
                     # Create a Response AKA FlowRun for each contact for Follow Up


### PR DESCRIPTION
* Introduce a new `pollrun_type`, `TYPE_SPOOFED`. The previous pull request uses `get_or_create_universal` to create spoofed `PollRun` instances. This caused a bug where valid universal PollRuns were deleted when removing spoofed data.
* Convert `BaselineTerm.start_date` and `BaselineTerm.end_date` to store dates rather than datetimes. I do not expect this to cause loss of data.
* Factor out common pattern in retrieval of `BaselineTerm` answers.
* Fix missing baseline data line (cannot iterate through `defaultdict` in a Django template).