### PR TITLE
Filter data on baseline chart page by region.

### DIFF
--- a/tracpro/baseline/tests/test_models.py
+++ b/tracpro/baseline/tests/test_models.py
@@ -86,7 +86,7 @@ class BaselineTermTest(TracProDataTest):
 
     def test_baseline_all_regions(self):
         """ Answers were 10, 20 and 30: Total should be 10 + 20 + 30 = 60 """
-        baseline_dict, dates = self.baselineterm.get_baseline(regions=None)
+        baseline_dict, dates = self.baselineterm.get_baseline(regions=None, region_selected=0)
 
         self.assertEqual(len(baseline_dict), 2)  # Two regions, two sets of baseline values
         # Two answers, 10 + 20 = 30
@@ -100,7 +100,7 @@ class BaselineTermTest(TracProDataTest):
 
     def test_baseline_single_region(self):
         """ Answers were 10 and 20 for region1 """
-        baseline_dict, dates = self.baselineterm.get_baseline(regions=[self.region1])
+        baseline_dict, dates = self.baselineterm.get_baseline(regions=[self.region1], region_selected=0)
 
         self.assertEqual(len(baseline_dict), 1)  # One regions, one baseline
         # Two answers sum = 10 + 20 = 30
@@ -128,7 +128,7 @@ class BaselineTermTest(TracProDataTest):
                 submitted_on=self.end_date,
                 category=u'')
 
-        baseline_dict, dates = self.baselineterm.get_baseline(regions=[self.region1])
+        baseline_dict, dates = self.baselineterm.get_baseline(regions=[self.region1], region_selected=0)
 
         self.assertEqual(len(baseline_dict), 1)  # One regions, one baseline
         # Two sets of baseline answers
@@ -143,10 +143,11 @@ class BaselineTermTest(TracProDataTest):
         Region 1 values [9, 8] + [15, 10]  = [24, 18]
         Region 2 values [25, 20]
         """
-        follow_ups, dates = self.baselineterm.get_follow_up(regions=None)
+        follow_ups, dates, all_regions = self.baselineterm.get_follow_up(regions=None, region_selected=0)
 
         self.assertEqual(len(dates), 3)  # 3 dates
         self.assertEqual(len(follow_ups), 2)  # 2 regions for the follow up dictionary
+        self.assertEqual(len(all_regions), 2)  # 2 regions in all the data
         # Sum the follow up data for two contacts in Region 1
         self.assertEqual(
             follow_ups[self.region1.name]["values"],
@@ -161,10 +162,11 @@ class BaselineTermTest(TracProDataTest):
         Region 1 values [9, 8] + [15, 10]  = [24, 18]
         Region 2 values [25, 20]
         """
-        follow_ups, dates = self.baselineterm.get_follow_up(regions=[self.region2])
+        follow_ups, dates, all_regions = self.baselineterm.get_follow_up(regions=[self.region2], region_selected=0)
 
         self.assertEqual(len(dates), 3)  # 3 dates
         self.assertEqual(len(follow_ups), 1)  # One region for the follow up dictionary
+        self.assertEqual(len(all_regions), 1)  # 1 region
         # Data for Region 2 only from one contact
         self.assertEqual(
             follow_ups[self.region2.name]["values"],

--- a/tracpro/baseline/views.py
+++ b/tracpro/baseline/views.py
@@ -73,8 +73,17 @@ class BaselineTermCRUDL(SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super(BaselineTermCRUDL.Read, self).get_context_data(**kwargs)
 
-            baseline_dict, baseline_dates = self.object.get_baseline(self.request.data_regions)
-            follow_ups, dates = self.object.get_follow_up(self.request.data_regions)
+            # Get the region from the region filter drop-down, if it was selected
+            region = int(self.request.GET.get('region', 0))
+            if region:
+                region_selected = region
+                context['region_selected'] = region_selected
+            else:
+                region_selected = 0
+
+            baseline_dict, baseline_dates = self.object.get_baseline(self.request.data_regions, region_selected)
+            follow_ups, dates, all_regions = self.object.get_follow_up(self.request.data_regions, region_selected)
+            context['all_regions'] = all_regions  # Return all regions in dataset for region drop-down
 
             # Create a list of all dates for this poll
             # Example: date_list =  ['09/01', '09/02', '09/03', ...]

--- a/tracpro/baseline/views.py
+++ b/tracpro/baseline/views.py
@@ -66,6 +66,8 @@ class BaselineTermCRUDL(SmartCRUDL):
             return kwargs
 
     class Read(OrgObjPermsMixin, SmartReadView):
+        fields = ("start_date", "end_date", "baseline_poll", "baseline_question",
+                  "follow_up_poll", "follow_up_question")
 
         def derive_queryset(self, **kwargs):
             return BaselineTerm.get_all(self.request.org)

--- a/tracpro/templates/baseline/baselineterm_header.html
+++ b/tracpro/templates/baseline/baselineterm_header.html
@@ -4,26 +4,47 @@
 <h2 class="page-header">
   {{ baselineterm.name }}
 </h2>
-
 <div class="clearfix">
-  {# if org_perms.contacts.contact_update or org_perms.contacts.contact_delete #}
+  <div class="pull-back">
+    <form class='form-inline' method='get'>
+      <label class='control-label' for='region-select'></label>
+      {% trans "Filter By Region" %}
+      <select id='region-select' class='form-control' onchange='onChartRegionChange(this)' name='region'>
+        <option value='0'>All Regions</option>
+        {% for region in all_regions %}
+          {% for key, value in region.items %}
+              {% if key == "response__contact__region" %}
+                  {% if value == region_selected %}
+                    <option selected='selected' value='{{ value }}'>
+                  {% else %}
+                    <option value='{{ value }}'>
+                  {% endif %}
+              {% else %}
+                  {{ value }}</option>
+              {% endif %}
+          {% endfor %}
+        {% endfor %}
+      </select>
+    </form>
+  </div>
+  {% if org_perms.baseline.baselineterm_update or org_perms.baseline.baselineterm_delete %}
     <div class="btn-group pull-away">
-      {# if org_perms.contacts.contact_update #}
+      {% if org_perms.baseline.baselineterm_update %}
         <a class="btn btn-default" href="{% url 'baseline.baselineterm_update' baselineterm.pk %}">
           <span class="glyphicon glyphicon-pencil">
             {% trans "Edit" %}
           </span>
         </a>
-      {# endif #}
-      {# if org_perms.contacts.contact_delete #}
+      {% endif %}
+      {% if org_perms.baseline.baselineterm_delete %}
         <button class="btn btn-default" type="button" data-toggle="modal" data-target="#confirm-delete-dialog">
           <span class="glyphicon glyphicon-trash">
             {% trans "Delete" %}
           </span>
         </button>
-      {# endif #}
+      {% endif %}
     </div>
-  {# endif #}
+  {% endif %}
 </div>
 
 <form id="delete-form" method="post" action="{% url 'baseline.baselineterm_delete' baselineterm.pk %}">
@@ -57,6 +78,9 @@
 
 {% block extra-script %}
   <script>
+    function onChartRegionChange(ctrl) {
+      ctrl.form.submit();
+    }
     function onConfirmDelete() {
       $('#delete-form').submit();
     }

--- a/tracpro/templates/baseline/baselineterm_read.html
+++ b/tracpro/templates/baseline/baselineterm_read.html
@@ -11,6 +11,7 @@
 
   {% include 'baseline/baselineterm_header.html' %}
 
+  <br />
   <div id="container" style="min-width: 310px; height: 400px; max-width: 800px; margin: 0 auto"></div>
 
 {% endblock pre-content %}


### PR DESCRIPTION
New drop-down on the baseline read page that allows user to filter chart by region. 

Also includes a filter by the regions from the session variable.

(This is take 2 after the first attempt got out of sync with master.)