### PR TITLE
Homepage baseline list

### DIFF
--- a/tracpro/home/views.py
+++ b/tracpro/home/views.py
@@ -23,9 +23,9 @@ class HomeView(OrgPermsMixin, SmartTemplateView):
     def get_context_data(self, **kwargs):
         context = super(HomeView, self).get_context_data(**kwargs)
         context['polls'] = Poll.get_all(self.request.org).order_by('name')
-
         # Loop through all baseline terms, until we find one with data
-        for baselineterm in BaselineTerm.objects.all().order_by('-end_date'):
+        baselineterms = BaselineTerm.objects.all().order_by('-end_date')
+        for baselineterm in baselineterms:
             data_found = baselineterm.check_for_data(self.request.data_regions)
             if data_found:
                 answers_dict, baseline_dict, all_regions, date_list = chart_baseline(
@@ -36,5 +36,8 @@ class HomeView(OrgPermsMixin, SmartTemplateView):
                 context['answers_dict'] = answers_dict
                 context['baselineterm'] = baselineterm
                 break  # Found our baseline chart with data, send it back to the view
+
+        # Return top 5 baseline terms only
+        context['baselineterms'] = baselineterms[0:5]
 
         return context

--- a/tracpro/static/less/trac.less
+++ b/tracpro/static/less/trac.less
@@ -124,6 +124,9 @@ footer {
 /**
  * Helper classes
  */
+.bottom-margin {
+  margin-bottom: 1em;
+}
 .centered {
   text-align: center;
 }

--- a/tracpro/static/less/trac.less
+++ b/tracpro/static/less/trac.less
@@ -105,6 +105,13 @@ footer {
   margin: 0 auto
 }
 
+.chart-home {
+  min-width: 210px;
+  max-width: 800px;
+  height: 300px;
+  margin: 0 auto;
+}
+
 .chart-no-data {
   border: 2px dashed #DDDDDD;
   padding: 1em;

--- a/tracpro/templates/baseline/baselineterm_chart.html
+++ b/tracpro/templates/baseline/baselineterm_chart.html
@@ -1,6 +1,7 @@
 <script src="http://code.highcharts.com/modules/exporting.js"></script>
 <script>
 $(function () {
+    {% if baselineterm %}
     $('#container').highcharts({
         title: {
             text: '{{ baselineterm.name|escapejs }}'
@@ -43,5 +44,8 @@ $(function () {
         {% endfor %}
         ]
     });
+    {% else %}
+        $('#container').html('<div class="alert alert-info">No baseline data exists.</div>');
+    {% endif %}
 });
 </script>

--- a/tracpro/templates/home/home.html
+++ b/tracpro/templates/home/home.html
@@ -10,7 +10,7 @@
       {% trans "You don't have access to any regions. Contact your administrator." %}
     </div>
   {% else %}
-    <div class='row' style='margin-bottom: 1em' >
+    <div class='row bottom-margin'>
         <div class='col-md-6'>
           <h2>
             {% trans "Latest Baseline Chart" %}
@@ -97,7 +97,7 @@
         {% trans "Latest Polling" %}
       </h2>
     </div>
-    <div class='row ng-cloak' ng-cloak='' style='margin-bottom: 1em' ng-controller='LatestPollRunsController'>
+    <div class='row ng-cloak bottom-margin' ng-cloak='' ng-controller='LatestPollRunsController'>
       <div class='col-md-12'>
         <table class='table table-striped' style='width: 100%'>
           <thead>

--- a/tracpro/templates/home/home.html
+++ b/tracpro/templates/home/home.html
@@ -10,17 +10,73 @@
       {% trans "You don't have access to any regions. Contact your administrator." %}
     </div>
   {% else %}
-    <h2>
-        {% trans "Latest Baseline Data" %}
-      </h2>
-      <div class='row' style='margin-bottom: 1em' >
-        <a href='/baselineterm/read/{{ baselineterm.pk }}/'>
-          <div class='col-md-12'>
-            <div id="container" style="min-width: 210px; height: 300px; max-width: 800px; margin: 0 auto">
-            </div>
+    <div class='row' style='margin-bottom: 1em' >
+        <div class='col-md-6'>
+          <h2>
+            {% trans "Latest Baseline Chart" %}
+          </h2>
+          <div id="container" style="min-width: 210px; height: 300px; max-width: 800px; margin: 0 auto">
           </div>
-        </a>
-      </div>
+        </div>
+        <div class='col-md-6'>
+          <h2>
+            {% trans "Latest Baseline Terms" %}
+          </h2>
+          <div class='btn-group pull-away'>
+            <a class='btn btn-default' href='{% url 'baseline.baselineterm_list' %}'>
+              <span class='glyphicon glyphicon-th-list'></span>
+              {% trans "View All" %}
+            </a>
+          </div>
+          <table class='table table-striped' style='width: 100%'>
+          <thead>
+            <tr>
+              <th>
+                {% trans "Name" %}
+              </th>
+              <th>
+                {% trans "Start Date" %}
+              </th>
+              <th>
+                {% trans "End Date" %}
+              </th>
+              <th>
+                {% trans "Baseline Question" %}
+              </th>
+              <th>
+                {% trans "Follow Up Question" %}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for baselinetermitem in baselineterms %}
+              <tr>
+                <td>
+                  <a href='/baselineterm/read/{{ baselinetermitem.pk }}/'>
+                    {{ baselinetermitem.name }}
+                  </a>
+                  {% if baselinetermitem.pk == baselineterm.pk %}
+                    (displayed)
+                  {% endif %}
+                </td>
+                <td>
+                  {{ baselinetermitem.start_date | date:"F d, Y"  }}
+                </td>
+                <td>
+                  {{ baselinetermitem.end_date | date:"F d, Y"  }}
+                </td>
+                <td>
+                  {{ baselinetermitem.baseline_question }}
+                </td>
+                <td>
+                  {{ baselinetermitem.follow_up_question }}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+          </table>
+        </div>
+    </div>
 
     <div class='page-header'>
       <div class='btn-group pull-away'>

--- a/tracpro/templates/home/home.html
+++ b/tracpro/templates/home/home.html
@@ -15,7 +15,7 @@
           <h2>
             {% trans "Latest Baseline Chart" %}
           </h2>
-          <div id="container" style="min-width: 210px; height: 300px; max-width: 800px; margin: 0 auto">
+          <div id="container" class="chart-home">
           </div>
         </div>
         <div class='col-md-6'>

--- a/tracpro/templates/home/home.html
+++ b/tracpro/templates/home/home.html
@@ -54,7 +54,7 @@
             {% for baselinetermitem in baselineterms %}
               <tr>
                 <td>
-                  <a href='/baselineterm/read/{{ baselinetermitem.pk }}/'>
+                  <a href='{% url "baseline.baselineterm_read" baselinetermitem.pk %}'>
                     {{ baselinetermitem.name }}
                   </a>
                   {% if baselinetermitem.pk == baselineterm.pk %}
@@ -62,10 +62,10 @@
                   {% endif %}
                 </td>
                 <td>
-                  {{ baselinetermitem.start_date | date:"F d, Y"  }}
+                  {{ baselinetermitem.start_date|date:"F d, Y"  }}
                 </td>
                 <td>
-                  {{ baselinetermitem.end_date | date:"F d, Y"  }}
+                  {{ baselinetermitem.end_date|date:"F d, Y"  }}
                 </td>
                 <td>
                   {{ baselinetermitem.baseline_question }}

--- a/tracpro/templates/home/home.html
+++ b/tracpro/templates/home/home.html
@@ -19,14 +19,16 @@
           </div>
         </div>
         <div class='col-md-6'>
-          <h2>
-            {% trans "Latest Baseline Terms" %}
-          </h2>
-          <div class='btn-group pull-away'>
-            <a class='btn btn-default' href='{% url 'baseline.baselineterm_list' %}'>
-              <span class='glyphicon glyphicon-th-list'></span>
-              {% trans "View All" %}
-            </a>
+          <div class='page-header'>
+            {% if org_perms.baseline.baselineterm_list %}
+              <a class='btn btn-default pull-away' href='{% url 'baseline.baselineterm_list' %}'>
+                <span class='glyphicon glyphicon-th-list'></span>
+                {% trans "View All" %}
+              </a>
+            {% endif %}
+            <h2>
+              {% trans "Latest Baseline Terms" %}
+            </h2>
           </div>
           <table class='table table-striped' style='width: 100%'>
           <thead>


### PR DESCRIPTION
Add a list of baseline terms to the homepage.
Remove the link on the baseline chart itself, this is now replaced by the list.