### PR TITLE
Handle non-existant Poll in PollRun.by_poll

### DIFF
--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -44,6 +44,15 @@ class Window(Enum):
             return (now - relativedelta(days=self.ordinal), now)
 
 
+class PollQuerySet(models.QuerySet):
+
+    def active(self):
+        return self.filter(is_active=True)
+
+    def by_org(self, org):
+        return self.filter(org=org)
+
+
 @python_2_unicode_compatible
 class Poll(models.Model):
     """
@@ -59,6 +68,8 @@ class Poll(models.Model):
 
     is_active = models.BooleanField(
         default=True, help_text=_("Whether this item is active"))
+
+    objects = PollQuerySet.as_manager()
 
     def __str__(self):
         return self.name

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -117,7 +117,7 @@ class Poll(models.Model):
 
     @classmethod
     def get_all(cls, org):
-        return org.polls.filter(is_active=True)
+        return Poll.objects.active().by_org(org)
 
     def get_questions(self):
         return self.questions.filter(is_active=True).order_by('order')

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -44,15 +44,6 @@ class Window(Enum):
             return (now - relativedelta(days=self.ordinal), now)
 
 
-class PollQuerySet(models.QuerySet):
-
-    def active(self):
-        return self.filter(is_active=True)
-
-    def by_org(self, org):
-        return self.filter(org=org)
-
-
 @python_2_unicode_compatible
 class Poll(models.Model):
     """
@@ -68,8 +59,6 @@ class Poll(models.Model):
 
     is_active = models.BooleanField(
         default=True, help_text=_("Whether this item is active"))
-
-    objects = PollQuerySet.as_manager()
 
     def __str__(self):
         return self.name
@@ -117,7 +106,7 @@ class Poll(models.Model):
 
     @classmethod
     def get_all(cls, org):
-        return Poll.objects.active().by_org(org)
+        return org.polls.filter(is_active=True)
 
     def get_questions(self):
         return self.questions.filter(is_active=True).order_by('order')

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import (
     HttpResponse, HttpResponseBadRequest, HttpResponseRedirect, JsonResponse)
+from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 
 from smartmin import views as smartmin
@@ -310,8 +311,8 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def derive_poll(self):
             def fetch():
-                return Poll.objects.get(
-                    pk=self.kwargs['poll'], org=self.request.org, is_active=True)
+                poll_qs = Poll.objects.active().by_org(self.request.org)
+                return get_object_or_404(poll_qs, pk=self.kwargs['poll'])
             return get_obj_cacheable(self, '_poll', fetch)
 
         def derive_queryset(self, **kwargs):

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -33,7 +33,7 @@ class PollCRUDL(smartmin.SmartCRUDL):
 
         def get_queryset(self):
             """Only allow viewing active polls for the current org."""
-            return Poll.objects.active().by_org(self.request.org)
+            return Poll.get_all(self.request.org)
 
     class Read(PollMixin, OrgObjPermsMixin, smartmin.SmartReadView):
 
@@ -168,8 +168,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             try:
-                poll = Poll.objects.get(
-                    org=self.request.org, pk=request.POST.get('poll'))
+                poll = Poll.get_all(self.request.org).get(pk=request.POST.get('poll'))
             except Poll.DoesNotExist:
                 return HttpResponseBadRequest()
 
@@ -313,8 +312,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def derive_poll(self):
             def fetch():
-                poll_qs = Poll.objects.active().by_org(self.request.org)
-                return get_object_or_404(poll_qs, pk=self.kwargs['poll'])
+                return get_object_or_404(Poll.get_all(self.request.org), pk=self.kwargs['poll'])
             return get_obj_cacheable(self, '_poll', fetch)
 
         def derive_queryset(self, **kwargs):

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -22,15 +22,20 @@ from tracpro.contacts.models import Contact
 from tracpro.groups.models import Group
 
 from . import charts, forms, tasks
-from .models import (
-    Poll, Question, PollRun, Response, Window)
+from .models import Poll, Question, PollRun, Response, Window
 
 
 class PollCRUDL(smartmin.SmartCRUDL):
     model = Poll
     actions = ('read', 'update', 'list', 'select')
 
-    class Read(OrgObjPermsMixin, smartmin.SmartReadView):
+    class PollMixin(object):
+
+        def get_queryset(self):
+            """Only allow viewing active polls for the current org."""
+            return Poll.objects.active().by_org(self.request.org)
+
+    class Read(PollMixin, OrgObjPermsMixin, smartmin.SmartReadView):
 
         def get_context_data(self, **kwargs):
             context = super(PollCRUDL.Read, self).get_context_data(**kwargs)
@@ -60,7 +65,7 @@ class PollCRUDL(smartmin.SmartCRUDL):
             context['questions'] = questions
             return context
 
-    class Update(OrgObjPermsMixin, smartmin.SmartUpdateView):
+    class Update(PollMixin, OrgObjPermsMixin, smartmin.SmartUpdateView):
         exclude = ('is_active', 'flow_uuid', 'org')
         form_class = forms.PollForm
 
@@ -70,14 +75,11 @@ class PollCRUDL(smartmin.SmartCRUDL):
                     question_id = field_key.split('__')[2]
                     Question.objects.filter(pk=question_id, poll=self.object).update(text=value)
 
-    class List(OrgPermsMixin, smartmin.SmartListView):
+    class List(PollMixin, OrgPermsMixin, smartmin.SmartListView):
         fields = ('name', 'questions', 'pollruns', 'last_conducted')
         field_config = {'pollruns': {'label': _("Dates")}}
         link_fields = ('name', 'pollruns')
         default_order = ('name',)
-
-        def derive_queryset(self, **kwargs):
-            return Poll.get_all(self.request.org)
 
         def derive_pollruns(self, obj):
             return obj.get_pollruns(


### PR DESCRIPTION
Fixes this error:

```
  File "/var/www/tracpro/source/tracpro/polls/views.py", line 318, in derive_queryset
    return self.derive_poll().get_pollruns(
  File "/var/www/tracpro/source/tracpro/polls/views.py", line 315, in derive_poll
    return get_obj_cacheable(self, '_poll', fetch)
  File "/var/www/tracpro/env/src/dash/dash/utils/__init__.py", line 85, in get_obj_cacheable
    calculated = calculate()
  File "/var/www/tracpro/source/tracpro/polls/views.py", line 314, in fetch
    pk=self.kwargs['poll'], org=self.request.org, is_active=True)
DoesNotExist: Poll matching query does not exist.
```

The Poll in question was "2", which doesn't look nefarious. I will investigate in case a user was erroneously being led to a Poll they should not be able to see.