### PR TITLE
Baseline data first results only

### DIFF
--- a/tracpro/baseline/forms.py
+++ b/tracpro/baseline/forms.py
@@ -65,8 +65,7 @@ class SpoofDataForm(forms.Form):
         "Baseline poll data will be submitted on this date. "
         "Follow up data will start on this date."))
     end_date = forms.DateField(help_text=_(
-        "Follow up data will end on this date. "
-        "If dates go beyond 1 week, a second set of baseline answers will be created."))
+        "Follow up data will end on this date. "))
     baseline_question = QuestionModelChoiceField(queryset=Question.objects.all().order_by('poll__name', 'text'),
                                                  help_text=_("Select a baseline question which " +
                                                              "will have numeric answers only."))

--- a/tracpro/baseline/models.py
+++ b/tracpro/baseline/models.py
@@ -90,7 +90,9 @@ class BaselineTerm(models.Model):
         dates_dict = {}
         dates = []
         for region_name in set(a.region_name.encode('ascii') for a in answers):
-            answers_by_region = answers.filter(region_name=region_name)
+            # Retrieve the first result per contact for baseline
+            answers_by_region = answers.order_by('response__contact', 'submitted_on').distinct('response__contact')
+            answers_by_region = answers_by_region.filter(region_name=region_name)
             answer_sums, dates = answers_by_region.numeric_sum_group_by_date()
             region_answers[region_name] = {'values': answer_sums}
             dates_dict[region_name] = dates
@@ -109,6 +111,7 @@ class BaselineTerm(models.Model):
         dates = []
         for region_name in set(a.region_name.encode('ascii') for a in answers):
             answers_by_region = answers.filter(region_name=region_name)
+            answers_by_region = answers_by_region.order_by('submitted_on')
             answer_sums, dates = answers_by_region.numeric_sum_group_by_date()
             region_answers[region_name] = {'values': answer_sums}
             dates_dict[region_name] = dates

--- a/tracpro/baseline/tests/test_models.py
+++ b/tracpro/baseline/tests/test_models.py
@@ -101,7 +101,6 @@ class BaselineTermTest(TracProDataTest):
     def test_baseline_single_region(self):
         """ Answers were 10 and 20 for region1 """
         baseline_dict, dates = self.baselineterm.get_baseline(regions=[self.region1], region_selected=0)
-
         self.assertEqual(len(baseline_dict), 1)  # One regions, one baseline
         # Two answers sum = 10 + 20 = 30
         self.assertEqual(
@@ -111,8 +110,8 @@ class BaselineTermTest(TracProDataTest):
     def test_baseline_single_region_multiple_answers(self):
         """
         Answers were 10 and 20 for region1
-        Add another answer for both region contacts at a later date
-        Baseline should be retrieved from all responses
+        Add other answers (100) for both region contacts at a later date
+        Baseline should be retrieved from first set of responses
         """
         for contact in [self.contact1, self.contact2]:
             response = factories.Response(
@@ -131,12 +130,11 @@ class BaselineTermTest(TracProDataTest):
         baseline_dict, dates = self.baselineterm.get_baseline(regions=[self.region1], region_selected=0)
 
         self.assertEqual(len(baseline_dict), 1)  # One regions, one baseline
-        # Two sets of baseline answers
+        # One baseline answer
         # sum 1 = 10 + 20 = 30
-        # sum 2 = 100 + 100 = 200
         self.assertEqual(
             baseline_dict[self.region1.name]["values"],
-            [30, 200])
+            [30])
 
     def test_follow_up_all_regions(self):
         """

--- a/tracpro/baseline/views.py
+++ b/tracpro/baseline/views.py
@@ -143,12 +143,12 @@ class BaselineTermCRUDL(SmartCRUDL):
             start = self.form.cleaned_data['start_date']
             end = self.form.cleaned_data['end_date']
 
+            # Create a single PollRun for the Baseline Poll for all contacts
+            self.create_baseline(baseline_question.poll, start, contacts,
+                                 baseline_question, baseline_minimum, baseline_maximum)
+
             # Create a PollRun for each date from start to end dates for the Follow Up Poll
             for loop_count, follow_up_date in enumerate(rrule.rrule(rrule.DAILY, dtstart=start, until=end)):
-                if loop_count % 7 == 0:  # On the seventh day, add another set of baseline data
-                    # Create a single PollRun for the Baseline Poll
-                    self.create_baseline(baseline_question.poll, follow_up_date, contacts,
-                                         baseline_question, baseline_minimum, baseline_maximum)
                 follow_up_datetime = datetime.combine(follow_up_date, datetime.utcnow().time().replace(tzinfo=pytz.utc))
                 follow_up_pollrun = PollRun.objects.create_spoofed(
                     poll=follow_up_question.poll, conducted_on=follow_up_datetime)

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -623,8 +623,7 @@ class AnswerQuerySet(models.QuerySet):
         dates = []
         total = Decimal(0)
         answer_date = ""
-        answers = self.order_by('submitted_on')
-        for answer in answers:
+        for answer in self:
             if answer.category is not None:
                 # ignore answers with no category as they weren't in the
                 # required range


### PR DESCRIPTION
- Select the baseline results from the sum of the *first* set of regional contacts' results.
- Assume baseline will not change over time.
- Updated test to test for this.
- Updated spoof to create a single baseline at beginning of spoofed dataset.