### PR TITLE
Filter PollRun by org in addition to region

### DIFF
--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 from dash.utils import intersection
 from dash.utils.sync import ChangeType
 
-from temba.types import Contact as TembaContact
+from temba_client.types import Contact as TembaContact
 
 from tracpro.groups.models import Region, Group
 

--- a/tracpro/contacts/tests/test_models.py
+++ b/tracpro/contacts/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import mock
 
-from temba.types import Contact as TembaContact
+from temba_client.types import Contact as TembaContact
 
 from django.test.utils import override_settings
 from django.utils import timezone

--- a/tracpro/contacts/tests/test_views.py
+++ b/tracpro/contacts/tests/test_views.py
@@ -1,6 +1,6 @@
 import json
 
-from temba.types import Run
+from temba_client.types import Run
 
 from django.core.urlresolvers import reverse
 from django.utils import timezone

--- a/tracpro/contacts/views.py
+++ b/tracpro/contacts/views.py
@@ -178,7 +178,9 @@ class ContactCRUDL(SmartCRUDL):
             def fetch():
                 pollruns = OrderedDict()
                 qs = PollRun.objects.get_all(
-                    self.request.region, self.request.include_subregions)
+                    self.request.org,
+                    self.request.region,
+                    self.request.include_subregions)
                 qs = qs.order_by('-conducted_on')
                 for pollrun in qs[0:3]:
                     pollruns['pollrun_%d' % pollrun.pk] = pollrun

--- a/tracpro/groups/tests/test_models.py
+++ b/tracpro/groups/tests/test_models.py
@@ -3,7 +3,7 @@ import mock
 from django.contrib.auth.models import User
 from django.test.utils import override_settings
 
-from temba.types import Group as TembaGroup
+from temba_client.types import Group as TembaGroup
 
 from tracpro.test import factories
 from tracpro.test.cases import TracProDataTest, TracProTest

--- a/tracpro/msgs/tests/test_models.py
+++ b/tracpro/msgs/tests/test_models.py
@@ -5,7 +5,7 @@ from mock import patch
 from django.test.utils import override_settings
 from django.utils import timezone
 
-from temba.types import Broadcast
+from temba_client.types import Broadcast
 
 from tracpro.msgs.models import (
     Message, COHORT_ALL, COHORT_RESPONDENTS, COHORT_NONRESPONDENTS)

--- a/tracpro/orgs_ext/tests/test_utils.py
+++ b/tracpro/orgs_ext/tests/test_utils.py
@@ -3,7 +3,7 @@ from requests import HTTPError
 
 from django.test import TestCase
 
-from temba.base import TembaAPIError
+from temba_client.base import TembaAPIError
 
 from tracpro.test import factories
 

--- a/tracpro/orgs_ext/utils.py
+++ b/tracpro/orgs_ext/utils.py
@@ -2,7 +2,7 @@ import logging
 
 from requests import HTTPError
 
-from temba.base import TembaAPIError
+from temba_client.base import TembaAPIError
 
 
 logger = logging.getLogger(__name__)

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -111,8 +111,8 @@ class Poll(models.Model):
     def get_questions(self):
         return self.questions.filter(is_active=True).order_by('order')
 
-    def get_pollruns(self, region=None, include_subregions=True):
-        return PollRun.objects.get_all(region, include_subregions).filter(poll=self)
+    def get_pollruns(self, org, region=None, include_subregions=True):
+        return PollRun.objects.get_all(org, region, include_subregions).filter(poll=self)
 
 
 @python_2_unicode_compatible
@@ -236,12 +236,13 @@ class PollRunManager(models.Manager.from_queryset(PollRunQuerySet)):
         kwargs['conducted_on'] = for_date
         return self.create(**kwargs)
 
-    def get_all(self, region, include_subregions=True):
+    def get_all(self, org, region, include_subregions=True):
         """
         Get all active PollRuns for the region, plus sub-regions if
         specified.
         """
-        qs = self.get_queryset().active().select_related('poll', 'region')
+        qs = self.get_queryset().active().by_org(org)
+        qs = qs.select_related('poll', 'region')
         qs = qs.by_region(region, include_subregions)
         return qs
 

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -6,7 +6,7 @@ from celery.utils.log import get_task_logger
 from djcelery_transactions import task
 from django_redis import get_redis_connection
 
-from temba.utils import parse_iso8601, format_iso8601
+from temba_client.utils import parse_iso8601, format_iso8601
 
 from dash.orgs.models import Org
 from dash.utils import datetime_to_ms

--- a/tracpro/polls/tests/test_models.py
+++ b/tracpro/polls/tests/test_models.py
@@ -7,7 +7,7 @@ from mock import patch
 
 import pytz
 
-from temba.types import Flow, RuleSet, Run, RunValueSet
+from temba_client.types import Flow, RuleSet, Run, RunValueSet
 
 from django.utils import timezone
 

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -41,7 +41,9 @@ class PollCRUDL(smartmin.SmartCRUDL):
             context = super(PollCRUDL.Read, self).get_context_data(**kwargs)
             questions = self.object.get_questions()
             pollruns = self.object.get_pollruns(
-                self.request.region, self.request.include_subregions)
+                self.request.org,
+                self.request.region,
+                self.request.include_subregions)
 
             # if we're viewing "All Regions" don't include regional only pollruns
             if not self.request.region:
@@ -83,7 +85,9 @@ class PollCRUDL(smartmin.SmartCRUDL):
 
         def derive_pollruns(self, obj):
             return obj.get_pollruns(
-                self.request.region, self.request.include_subregions)
+                self.request.org,
+                self.request.region,
+                self.request.include_subregions)
 
         def get_questions(self, obj):
             return obj.get_questions().count()
@@ -207,6 +211,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def get_queryset(self):
             return PollRun.objects.get_all(
+                self.request.org,
                 self.request.region,
                 self.request.include_subregions)
 
@@ -225,6 +230,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def get_queryset(self):
             return PollRun.objects.get_all(
+                self.request.org,
                 self.request.region,
                 self.request.include_subregions)
 
@@ -301,6 +307,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def derive_queryset(self, **kwargs):
             return PollRun.objects.get_all(
+                self.request.org,
                 self.request.region,
                 self.request.include_subregions)
 
@@ -323,7 +330,9 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def derive_queryset(self, **kwargs):
             return self.derive_poll().get_pollruns(
-                self.request.region, self.request.include_subregions)
+                self.request.org,
+                self.request.region,
+                self.request.include_subregions)
 
         def get_context_data(self, **kwargs):
             context = super(PollRunCRUDL.ByPoll, self).get_context_data(**kwargs)
@@ -334,6 +343,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def get_queryset(self):
             qs = PollRun.objects.get_all(
+                self.request.org,
                 self.request.region,
                 self.request.include_subregions)
             qs = qs.order_by('-conducted_on')[0:5]


### PR DESCRIPTION
Fixed bug: If region is None, then we're returning results for other orgs as well.

Also renames `temba` -> `temba_client` as required by recent changes to rapidpro/rapidpro-python. (I've updated the master branches of our forks of smartmin, rapidpro-python, and dash with the latest from their upstream counterparts.)