### PR TITLE
Raise error on form init for Org edit.

### DIFF
--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -2,7 +2,6 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
-from temba_client.base import TembaAPIError
 from dash.orgs.forms import OrgForm
 
 
@@ -59,13 +58,7 @@ class SimpleOrgEditForm(OrgForm):
     def __init__(self, *args, **kwargs):
         super(SimpleOrgEditForm, self).__init__(*args, **kwargs)
 
-        try:
-            temba_fields = self.instance.get_temba_client().get_fields()
-        except TembaAPIError:
-            raise ValueError(
-                "This org does not have a functioning RapidPro API Key set up. " +
-                "Edit it via Site Manage drop-down, or ask your administrator to fix it.")
-
+        temba_fields = self.instance.get_temba_client().get_fields()
         field_choices = [(f.key, '{} ({})'.format(f.label, f.key))
                          for f in temba_fields]
         self.fields['facility_code_field'].choices = field_choices

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
+from temba_client.base import TembaAPIError
 from dash.orgs.forms import OrgForm
 
 
@@ -57,8 +58,16 @@ class SimpleOrgEditForm(OrgForm):
 
     def __init__(self, *args, **kwargs):
         super(SimpleOrgEditForm, self).__init__(*args, **kwargs)
+
+        try:
+            temba_fields = self.instance.get_temba_client().get_fields()
+        except TembaAPIError:
+            raise ValueError(
+                "This org does not have a functioning RapidPro API Key set up. " +
+                "Edit it via Site Manage drop-down, or ask your administrator to fix it.")
+
         field_choices = [(f.key, '{} ({})'.format(f.label, f.key))
-                         for f in self.instance.get_temba_client().get_fields()]
+                         for f in temba_fields]
         self.fields['facility_code_field'].choices = field_choices
         self.fields['facility_code_field'].initial = self.instance.facility_code_field
 

--- a/tracpro/orgs_ext/middleware.py
+++ b/tracpro/orgs_ext/middleware.py
@@ -10,7 +10,7 @@ class HandleTembaAPIError(object):
     def process_exception(self, request, exception):
 
         rapidProConnectionErrorString = _(
-            "RapidPro appears to be down right now or we cannot connect due to your internet connection. "
+            "RapidPro appears to be down right now. "
             "Please try again later.")
 
         if isinstance(exception, TembaAPIError):

--- a/tracpro/orgs_ext/middleware.py
+++ b/tracpro/orgs_ext/middleware.py
@@ -1,16 +1,32 @@
 from django.utils.translation import ugettext_lazy as _
 from django.http import HttpResponseBadRequest
 
-from temba_client.base import TembaAPIError
+from temba_client.base import TembaAPIError, TembaConnectionError
 
 
 class HandleTembaAPIError(object):
     """ Catch all Temba exception errors """
 
     def process_exception(self, request, exception):
+
+        rapidProConnectionErrorString = _(
+            "RapidPro appears to be down right now or we cannot connect due to your internet connection. "
+            "Please try again later.")
+
         if isinstance(exception, TembaAPIError):
+            rapidpro_connection_error_codes = ["502", "503", "504"]
+
+            if any(code in exception.caused_by.message for code in rapidpro_connection_error_codes):
+                return HttpResponseBadRequest(
+                    rapidProConnectionErrorString)
+
+            else:
+                return HttpResponseBadRequest(
+                    _("Org does not have a valid API Key. "
+                      "Please edit the org through Site Manage or contact your administrator."))
+
+        elif isinstance(exception, TembaConnectionError):
             return HttpResponseBadRequest(
-                _("Org does not have a valid API Key. " +
-                  "Please edit the org through Site Manage or contact your administrator."))
+                rapidProConnectionErrorString)
 
         pass

--- a/tracpro/orgs_ext/middleware.py
+++ b/tracpro/orgs_ext/middleware.py
@@ -1,0 +1,15 @@
+from django.utils.translation import ugettext_lazy as _
+from django.http import HttpResponseBadRequest
+
+from temba_client.base import TembaAPIError
+
+
+class HandleTembaAPIError(object):
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, TembaAPIError):
+            return HttpResponseBadRequest(
+                _("Org does not have a valid API Key. " +
+                  "Please edit the org through Site Manage or contact your administrator."))
+
+        pass

--- a/tracpro/orgs_ext/middleware.py
+++ b/tracpro/orgs_ext/middleware.py
@@ -5,6 +5,7 @@ from temba_client.base import TembaAPIError
 
 
 class HandleTembaAPIError(object):
+    """ Catch all Temba exception errors """
 
     def process_exception(self, request, exception):
         if isinstance(exception, TembaAPIError):

--- a/tracpro/orgs_ext/middleware.py
+++ b/tracpro/orgs_ext/middleware.py
@@ -11,7 +11,7 @@ class HandleTembaAPIError(object):
 
     def process_exception(self, request, exception):
 
-        rapidProConnectionErrorString = _(
+        rapidpro_connection_error_string = _(
             "RapidPro appears to be down right now. "
             "Please try again later.")
 
@@ -25,10 +25,10 @@ class HandleTembaAPIError(object):
                               "Please edit the org through Site Manage or contact your administrator."))
 
                     elif response.status_code >= 500:
-                        return HttpResponseBadRequest(rapidProConnectionErrorString)
+                        return HttpResponseBadRequest(rapidpro_connection_error_string)
 
         elif isinstance(exception, TembaConnectionError):
             return HttpResponseBadRequest(
-                rapidProConnectionErrorString)
+                rapidpro_connection_error_string)
 
         return None

--- a/tracpro/orgs_ext/middleware.py
+++ b/tracpro/orgs_ext/middleware.py
@@ -1,6 +1,8 @@
 from django.utils.translation import ugettext_lazy as _
 from django.http import HttpResponseBadRequest
 
+from requests import HTTPError
+
 from temba_client.base import TembaAPIError, TembaConnectionError
 
 
@@ -14,19 +16,19 @@ class HandleTembaAPIError(object):
             "Please try again later.")
 
         if isinstance(exception, TembaAPIError):
-            rapidpro_connection_error_codes = ["502", "503", "504"]
+            if isinstance(exception.caused_by, HTTPError):
+                response = exception.caused_by.response
+                if response is not None:
+                    if response.status_code == 403:
+                        return HttpResponseBadRequest(
+                            _("Org does not have a valid API Key. "
+                              "Please edit the org through Site Manage or contact your administrator."))
 
-            if any(code in exception.caused_by.message for code in rapidpro_connection_error_codes):
-                return HttpResponseBadRequest(
-                    rapidProConnectionErrorString)
-
-            else:
-                return HttpResponseBadRequest(
-                    _("Org does not have a valid API Key. "
-                      "Please edit the org through Site Manage or contact your administrator."))
+                    elif response.status_code >= 500:
+                        return HttpResponseBadRequest(rapidProConnectionErrorString)
 
         elif isinstance(exception, TembaConnectionError):
             return HttpResponseBadRequest(
                 rapidProConnectionErrorString)
 
-        pass
+        return None

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.utils.translation import ugettext_lazy as _
-from django.http import HttpResponseBadRequest
 
 from dash.orgs.views import OrgCRUDL, InferOrgMixin, OrgPermsMixin
 from dash.utils import ms_to_datetime
-
-from temba_client.base import TembaAPIError
 
 from smartmin.templatetags.smartmin import format_datetime
 from smartmin.views import SmartUpdateView
@@ -68,20 +65,7 @@ class OrgExtCRUDL(OrgCRUDL):
             else:
                 return None
 
-    class APIKeyMixin(object):
-        """ Mixin to determine whether RapidPro API Key is valid """
-
-        def dispatch(self, request, *args, **kwargs):
-            try:
-                self.request.org.get_temba_client().get_fields()
-                return super(OrgExtCRUDL.APIKeyMixin, self).dispatch(request, *args, **kwargs)
-
-            except TembaAPIError:
-                return HttpResponseBadRequest(
-                    _("Org does not have a valid API Key. " +
-                      "Please edit the org through Site Manage or contact your administrator."))
-
-    class Edit(APIKeyMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class Edit(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         fields = ('name', 'timezone', 'facility_code_field')
         form_class = forms.SimpleOrgEditForm
         permission = 'orgs.org_edit'

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -175,6 +175,7 @@ MIDDLEWARE_CLASSES = (
     'dash.orgs.middleware.SetOrgMiddleware',
     'tracpro.profiles.middleware.ForcePasswordChangeMiddleware',
     'tracpro.groups.middleware.UserRegionsMiddleware',
+    'tracpro.orgs_ext.middleware.HandleTembaAPIError',
 )
 
 ROOT_URLCONF = 'tracpro.urls'


### PR DESCRIPTION
Test this out by creating an org with no API key, then going to Administration-> Organization, select "Edit" button. 

I'm not 100% sure on what to do within __init__ to raise an error. Let me know if there is a better way @rebecca-caktus. 
