### PR TITLE
Contact Fields

### DIFF
--- a/tracpro/baseline/forms.py
+++ b/tracpro/baseline/forms.py
@@ -95,7 +95,7 @@ class SpoofDataForm(forms.Form):
         super(SpoofDataForm, self).__init__(*args, **kwargs)
 
         if org:
-            contacts = Contact.get_all(org).order_by('name')
+            contacts = Contact.objects.active().by_org(org).order_by('name')
             self.fields['contacts'].queryset = contacts
             questions = Question.objects.filter(poll__in=Poll.get_all(org))
             self.fields['baseline_question'].queryset = questions

--- a/tracpro/contacts/__init__.py
+++ b/tracpro/contacts/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "tracpro.contacts.apps.ContactConfig"

--- a/tracpro/contacts/apps.py
+++ b/tracpro/contacts/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class ContactConfig(AppConfig):
+    name = "tracpro.contacts"
+
+    def ready(self):
+        from . import signals  # noqa

--- a/tracpro/contacts/forms.py
+++ b/tracpro/contacts/forms.py
@@ -11,27 +11,16 @@ from .models import Contact
 
 
 class ContactForm(forms.ModelForm):
-    name = forms.CharField(max_length=128, label=_("Full name"))
-    urn = URNField(
-        label=_("Phone/Twitter"),
-        help_text=_("Phone number or Twitter handle of this contact."))
+    urn = URNField(label=_("Phone/Twitter"))
     region = ModifiedLevelTreeNodeChoiceField(
-        label=_("Region"), empty_label="",
-        queryset=Region.objects.none(),
-        help_text=_("Region where this contact lives."))
-    group = forms.ModelChoiceField(
-        label=_("Reporter Group"), empty_label="",
-        queryset=Group.objects.none(),
-        help_text=_("Reporter Group to which this contact belongs."))
-    facility_code = forms.CharField(
-        label=_("Facility Code"), max_length=16, required=False)
-    language = forms.CharField(
-        label=_("Language"), required=False,
-        widget=forms.TextInput(attrs={'class': 'language-field'}))
+        label=_("Region"), empty_label="", queryset=Region.objects.none())
 
     class Meta:
         model = Contact
         fields = forms.ALL_FIELDS
+        widgets = {
+            'language': forms.TextInput(attrs={'class': 'language-field'}),
+        }
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user')
@@ -47,5 +36,9 @@ class ContactForm(forms.ModelForm):
             # we must create a UUID for it.
             self.instance.uuid = str(uuid4())
 
+        self.fields['name'].required = True
+        self.fields['group'].required = True
+
         self.fields['region'].queryset = self.user.get_all_regions(org)
+        self.fields['group'].empty_label = ""
         self.fields['group'].queryset = Group.get_all(org).order_by('name')

--- a/tracpro/contacts/forms.py
+++ b/tracpro/contacts/forms.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
@@ -33,7 +35,17 @@ class ContactForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user')
-        super(ContactForm, self).__init__(*args, **kwargs)
         org = self.user.get_org()
+        super(ContactForm, self).__init__(*args, **kwargs)
+
+        self.instance.org = org
+        self.instance.modified_by = self.user
+        if not self.instance.pk:
+            self.instance.created_by = self.user
+
+            # Since we are creating this contact (rather than RapidPro),
+            # we must create a UUID for it.
+            self.instance.uuid = str(uuid4())
+
         self.fields['region'].queryset = self.user.get_all_regions(org)
         self.fields['group'].queryset = Group.get_all(org).order_by('name')

--- a/tracpro/contacts/forms.py
+++ b/tracpro/contacts/forms.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
@@ -31,9 +29,6 @@ class ContactForm(forms.ModelForm):
         self.instance.modified_by = self.user
         if not self.instance.pk:
             self.instance.created_by = self.user
-            # Since we are creating this contact (rather than RapidPro),
-            # we must create a UUID for it.
-            self.instance.uuid = str(uuid4())
 
         self.fields['name'].required = True
         self.fields['group'].required = True

--- a/tracpro/contacts/migrations/0006_contact_help_text.py
+++ b/tracpro/contacts/migrations/0006_contact_help_text.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0005_contact_temba_modified_on'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contact',
+            name='group',
+            field=models.ForeignKey(related_name='contacts', verbose_name='Reporter group', to='groups.Group', help_text='Reporter group to which this contact belongs.', null=True),
+        ),
+        migrations.AlterField(
+            model_name='contact',
+            name='name',
+            field=models.CharField(help_text='The name of this contact', max_length=128, verbose_name='Full name', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='contact',
+            name='region',
+            field=models.ForeignKey(related_name='contacts', verbose_name='Region', to='groups.Region', help_text='Region where this contact lives.'),
+        ),
+        migrations.AlterField(
+            model_name='contact',
+            name='urn',
+            field=models.CharField(help_text='Phone number or Twitter handle of this contact.', max_length=255, verbose_name='Phone/Twitter'),
+        ),
+    ]

--- a/tracpro/contacts/migrations/0007_add_data_field_model.py
+++ b/tracpro/contacts/migrations/0007_add_data_field_model.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0014_auto_20150722_1419'),
+        ('contacts', '0006_contact_help_text'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DataField',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('label', models.CharField(max_length=255, blank=True)),
+                ('key', models.CharField(max_length=255)),
+                ('value_type', models.CharField(max_length=1, choices=[('T', 'Text'), ('N', 'Decimal Number'), ('D', 'Datetime'), ('S', 'State'), ('I', 'District')])),
+                ('show_on_tracpro', models.BooleanField(default=False)),
+                ('org', models.ForeignKey(to='orgs.Org')),
+            ],
+            options={'ordering': ('label', 'key')},
+        ),
+        migrations.AlterUniqueTogether(
+            name='datafield',
+            unique_together=set([('org', 'key')]),
+        ),
+    ]

--- a/tracpro/contacts/migrations/0008_add_contactfield_model.py
+++ b/tracpro/contacts/migrations/0008_add_contactfield_model.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0007_add_data_field_model'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ContactField',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('value', models.CharField(max_length=255, null=True)),
+                ('contact', models.ForeignKey(to='contacts.Contact')),
+                ('field', models.ForeignKey(to='contacts.DataField')),
+            ],
+        ),
+    ]

--- a/tracpro/contacts/migrations/0009_show_facility_code_field.py
+++ b/tracpro/contacts/migrations/0009_show_facility_code_field.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+
+from django.db import models, migrations
+
+
+def show_facility_code_field(apps, schema_editor):
+    """Create a facility code Field for each active org."""
+    Org = apps.get_model('orgs', 'Org')
+    DataField = apps.get_model('contacts', 'DataField')
+
+    for org in Org.objects.filter(is_active=True):
+        # Must manually load config; get_config is not available.
+        config = json.loads(org.config) if org.config else {}
+        DataField.objects.create(
+            org=org,
+            key=config.pop("facility_code_field", "facility_code"),
+            value_type="T",  # Text
+            show_on_tracpro=True,
+        )
+
+        # Save the config without `facility_code_field`, which is no longer
+        # in use.
+        org.config = json.dumps(config) if config else None
+        org.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0008_add_contactfield_model'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            show_facility_code_field, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name='contact',
+            name='facility_code',
+        ),
+    ]

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from dateutil.parser import parse
 
+from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -267,6 +268,15 @@ class DataField(models.Model):
     @property
     def display_name(self):
         return (self.label or self.key).title()
+
+    def get_form_field(self, **kwargs):
+        if self.value_type == DataField.TYPE_DATETIME:
+            field_type = forms.DateTimeField
+        elif self.value_type == DataField.TYPE_DECIMAL:
+            field_type = forms.DecimalField
+        else:
+            field_type = forms.CharField
+        return field_type(label=self.display_name, required=False, **kwargs)
 
 
 class ContactFieldQuerySet(models.QuerySet):

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -161,7 +161,8 @@ class Contact(models.Model):
     def push(self, change_type):
         push_contact_change.delay(self.pk, change_type)
 
-    def release(self):
+    def delete(self):
+        """Deactivate the local copy & delete from RapidPro."""
         self.is_active = False
         self.save()
         self.push(ChangeType.deleted)

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -39,16 +39,19 @@ class Contact(models.Model):
     org = models.ForeignKey(
         'orgs.Org', verbose_name=_("Organization"), related_name="contacts")
     name = models.CharField(
-        verbose_name=_("Name"), max_length=128, blank=True,
+        verbose_name=_("Full name"), max_length=128, blank=True,
         help_text=_("The name of this contact"))
     urn = models.CharField(
-        verbose_name=_("URN"), max_length=255)
+        verbose_name=_("Phone/Twitter"),
+        max_length=255,
+        help_text=_("Phone number or Twitter handle of this contact."))
     region = models.ForeignKey(
         'groups.Region', verbose_name=_("Region"), related_name='contacts',
-        help_text=_("Region or state this contact lives in"))
+        help_text=_("Region where this contact lives."))
     group = models.ForeignKey(
         'groups.Group', null=True, verbose_name=_("Reporter group"),
-        related_name='contacts')
+        related_name='contacts',
+        help_text=_("Reporter group to which this contact belongs."))
     facility_code = models.CharField(
         max_length=160, verbose_name=_("Facility Code"), null=True, blank=True,
         help_text=_("Facility code for this contact"))

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -54,9 +54,6 @@ class Contact(models.Model):
         'groups.Group', null=True, verbose_name=_("Reporter group"),
         related_name='contacts',
         help_text=_("Reporter group to which this contact belongs."))
-    facility_code = models.CharField(
-        max_length=160, verbose_name=_("Facility Code"), null=True, blank=True,
-        help_text=_("Facility code for this contact"))
     language = models.CharField(
         max_length=3, verbose_name=_("Language"), null=True, blank=True,
         help_text=_("Language for this contact"))
@@ -95,12 +92,11 @@ class Contact(models.Model):
         temba_contact = TembaContact()
         temba_contact.name = self.name
         temba_contact.urns = [self.urn]
-        temba_contact.fields = {
-            self.org.facility_code_field: self.facility_code,
-        }
+        temba_contact.fields = {}
         temba_contact.groups = groups
         temba_contact.language = self.language
         temba_contact.uuid = self.uuid
+
         return temba_contact
 
     @classmethod
@@ -158,7 +154,6 @@ class Contact(models.Model):
             'region': region,
             'group': group,
             'language': temba_contact.language,
-            'facility_code': temba_contact.fields.get(org.facility_code_field, None),
             'uuid': temba_contact.uuid,
             'temba_modified_on': temba_contact.modified_on,
             'fields': temba_contact.fields,

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -116,6 +116,12 @@ class Contact(models.Model):
 
         return temba_contact
 
+    def delete(self):
+        """Deactivate the local copy & delete from RapidPro."""
+        self.is_active = False
+        self.save()
+        self.push(ChangeType.deleted)
+
     @classmethod
     def get_or_fetch(cls, org, uuid):
         """Gets a contact by UUID.
@@ -178,12 +184,6 @@ class Contact(models.Model):
 
     def push(self, change_type):
         push_contact_change.delay(self.pk, change_type)
-
-    def delete(self):
-        """Deactivate the local copy & delete from RapidPro."""
-        self.is_active = False
-        self.save()
-        self.push(ChangeType.deleted)
 
     def save(self, *args, **kwargs):
         self.name = self.name or ""  # RapidPro might return blank or null values.

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -41,8 +41,6 @@ class ContactManager(models.Manager.from_queryset(ContactQuerySet)):
         if group and org.pk != group.org_id:
             raise ValidationError("Group does not belong to Org.")
 
-        data_field_values = kwargs.pop('_data_field_values', None)
-
         if not uuid:
             # There will be no UUID if we are creating this Contact
             # (rather than importing from RapidPro).
@@ -55,8 +53,7 @@ class ContactManager(models.Manager.from_queryset(ContactQuerySet)):
             push_created = False
 
         contact = super(ContactManager, self).create(
-            org=org, region=region, group=group, **kwargs)
-        contact._data_field_values = data_field_values
+            org=org, region=region, group=group, uuid=uuid, **kwargs)
 
         if push_created:
             contact.push(ChangeType.created)
@@ -111,6 +108,10 @@ class Contact(models.Model):
         editable=False)
 
     objects = ContactManager()
+
+    def __init__(self, *args, **kwargs):
+        self._data_field_values = kwargs.pop('_data_field_values', None)
+        super(Contact, self).__init__(*args, **kwargs)
 
     def __str__(self):
         return self.name or self.get_urn()[1]

--- a/tracpro/contacts/signals.py
+++ b/tracpro/contacts/signals.py
@@ -12,10 +12,12 @@ def set_data_field_values(sender, instance, **kwargs):
     By doing this, we can quickly show meaningful data when DataField
     visibility is toggled.
     """
-    data_field_values = getattr(instance, '_data_field_values', None)
-    if data_field_values is not None:
+    if not hasattr(instance, '_data_field_values'):
+        return
+
+    if instance._data_field_values is not None:
         data_fields = {f.key: f for f in instance.org.datafield_set.all()}
-        for key, value in data_field_values.items():
+        for key, value in instance._data_field_values.items():
             if key not in data_fields:
                 continue  # Don't update fields we don't have a record for.
 
@@ -26,3 +28,5 @@ def set_data_field_values(sender, instance, **kwargs):
                 contact=instance, field=data_fields[key])
             contact_field.set_value(value)
             contact_field.save()
+
+    del instance._data_field_values

--- a/tracpro/contacts/signals.py
+++ b/tracpro/contacts/signals.py
@@ -1,0 +1,28 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import Contact, ContactField
+
+
+@receiver(post_save, sender=Contact)
+def set_data_field_values(sender, instance, **kwargs):
+    """Hook to update the field values for a Contact.
+
+    Stores all values, even for DataFields that are not visible.
+    By doing this, we can quickly show meaningful data when DataField
+    visibility is toggled.
+    """
+    data_field_values = getattr(instance, '_data_field_values', None)
+    if data_field_values is not None:
+        data_fields = {f.key: f for f in instance.org.datafield_set.all()}
+        for key, value in data_field_values.items():
+            if key not in data_fields:
+                continue  # Don't update fields we don't have a record for.
+
+            # Remove empty strings for consistency with RapidPro.
+            value = value or None
+
+            contact_field, _ = ContactField.objects.get_or_create(
+                contact=instance, field=data_fields[key])
+            contact_field.set_value(value)
+            contact_field.save()

--- a/tracpro/contacts/tasks.py
+++ b/tracpro/contacts/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.db.models.loading import get_model
+from django.apps import apps
 from django.utils import timezone
 
 from celery.utils.log import get_task_logger
@@ -100,5 +100,5 @@ def sync_org_fields(org_pk):
     """
     org = Org.objects.get(pk=org_pk)
     logger.info("Syncing fields for {}.".format(org.name))
-    get_model('contacts', 'DataField').objects.sync(org)
+    apps.get_model('contacts', 'DataField').objects.sync(org)
     logger.info("Finished syncing fields for {}.".format(org.name))

--- a/tracpro/contacts/tasks.py
+++ b/tracpro/contacts/tasks.py
@@ -49,7 +49,7 @@ def sync_org_contacts(org_id):
 
     sync_groups = [r.uuid for r in Region.get_all(org)] + [g.uuid for g in Group.get_all(org)]
 
-    most_recent_contact = Contact.get_all(org=org).filter(temba_modified_on__isnull=False)
+    most_recent_contact = Contact.objects.by_org(org).active().exclude(temba_modified_on=None)
     most_recent_contact = most_recent_contact.order_by('-temba_modified_on').first()
     if most_recent_contact:
         last_time = most_recent_contact.temba_modified_on

--- a/tracpro/contacts/tests/factories.py
+++ b/tracpro/contacts/tests/factories.py
@@ -16,10 +16,14 @@ class Contact(factory_utils.SmartModelFactory):
     uuid = factory_utils.FuzzyUUID()
     org = factory.SubFactory("tracpro.test.factories.Org")
     urn = factory.Sequence(lambda n: random.choice(("twitter:contact", "tel:123")) + str(n))
-    region = factory.SubFactory("tracpro.test.factories.Region")
 
     class Meta:
         model = models.Contact
+
+    @factory.lazy_attribute
+    def region(self):
+        from tracpro.test.factories import Region
+        return Region(org=self.org)
 
 
 class TwitterContact(Contact):

--- a/tracpro/contacts/tests/test_models.py
+++ b/tracpro/contacts/tests/test_models.py
@@ -26,7 +26,7 @@ class ContactTest(TracProDataTest):
         mock_create_contact.return_value = TembaContact.create(
             uuid='C-007', name="Mo Polls",
             urns=['tel:078123'], groups=['G-001', 'G-005'],
-            fields={'facility_code': 'FC234'},
+            fields={},
             language='eng', modified_on=timezone.now())
 
         contact = factories.Contact(
@@ -36,7 +36,6 @@ class ContactTest(TracProDataTest):
         self.assertEqual(contact.name, "Mo Polls")
         self.assertEqual(contact.urn, 'tel:078123')
         self.assertEqual(contact.region, self.region1)
-        self.assertEqual(contact.facility_code, 'FC234')
         self.assertEqual(contact.language, 'eng')
         self.assertEqual(contact.created_by, self.user1)
         self.assertIsNotNone(contact.created_on)
@@ -54,7 +53,7 @@ class ContactTest(TracProDataTest):
         mock_get_contact.return_value = TembaContact.create(
             uuid='C-007', name="Mo Polls",
             urns=['tel:078123'], groups=['G-001', 'G-005'],
-            fields={'facility_code': 'FC234'},
+            fields={},
             language='eng', modified_on=timezone.now())
         # get locally
         contact = Contact.get_or_fetch(self.unicef, 'C-001')
@@ -69,7 +68,7 @@ class ContactTest(TracProDataTest):
         temba_contact = TembaContact.create(
             uuid='C-007', name="Jan", urns=['tel:123'],
             groups=['G-001', 'G-007'],
-            fields={'facility_code': 'FC234', 'gender': 'M'},
+            fields={'gender': 'M'},
             language='eng', modified_on=modified_date)
 
         kwargs = Contact.kwargs_from_temba(self.unicef, temba_contact)
@@ -80,7 +79,6 @@ class ContactTest(TracProDataTest):
             'urn': 'tel:123',
             'region': self.region1,
             'group': self.group3,
-            'facility_code': 'FC234',
             'language': 'eng',
             'temba_modified_on': modified_date,
         })
@@ -92,7 +90,7 @@ class ContactTest(TracProDataTest):
         temba_contact = self.contact1.as_temba()
         self.assertEqual(temba_contact.name, "Ann")
         self.assertEqual(temba_contact.urns, ['tel:1234'])
-        self.assertEqual(temba_contact.fields, {'facility_code': 'FC123'})
+        self.assertEqual(temba_contact.fields, {})
         self.assertEqual(temba_contact.groups, ['G-001', 'G-005'])
         self.assertEqual(temba_contact.uuid, 'C-001')
 

--- a/tracpro/contacts/tests/test_models.py
+++ b/tracpro/contacts/tests/test_models.py
@@ -29,9 +29,9 @@ class ContactTest(TracProDataTest):
             fields={'facility_code': 'FC234'},
             language='eng', modified_on=timezone.now())
 
-        contact = Contact.create(
-            self.unicef, self.user1, "Mo Polls", 'tel:078123',
-            self.region1, self.group1, 'FC234', 'eng')
+        contact = factories.Contact(
+            org=self.unicef, created_by=self.user1, modified_by=self.user1,
+            urn="tel:078123", region=self.region1, group=self.group1)
 
         self.assertEqual(contact.name, "Mo Polls")
         self.assertEqual(contact.urn, 'tel:078123')
@@ -96,9 +96,9 @@ class ContactTest(TracProDataTest):
         self.assertEqual(temba_contact.groups, ['G-001', 'G-005'])
         self.assertEqual(temba_contact.uuid, 'C-001')
 
-    def test_get_all(self):
-        self.assertEqual(len(Contact.get_all(self.unicef)), 5)
-        self.assertEqual(len(Contact.get_all(self.nyaruka)), 1)
+    def test_by_org(self):
+        self.assertEqual(len(Contact.objects.active().by_org(self.unicef)), 5)
+        self.assertEqual(len(Contact.objects.active().by_org(self.nyaruka)), 1)
 
     def test_get_responses(self):
         date1 = self.datetime(2014, 1, 1, 7, 0)

--- a/tracpro/contacts/tests/test_models.py
+++ b/tracpro/contacts/tests/test_models.py
@@ -125,8 +125,8 @@ class ContactTest(TracProDataTest):
         BROKER_BACKEND='memory',
     )
     @mock.patch('dash.orgs.models.TembaClient.delete_contact')
-    def test_release(self, mock_delete_contact):
-        self.contact1.release()
+    def test_delete(self, mock_delete_contact):
+        self.contact1.delete()
         self.assertFalse(self.contact1.is_active)
 
         self.assertEqual(mock_delete_contact.call_count, 1)

--- a/tracpro/contacts/tests/test_views.py
+++ b/tracpro/contacts/tests/test_views.py
@@ -176,8 +176,7 @@ class ContactCRUDLTest(TracProDataTest):
         # try to delete contact from other org
         response = self.url_post(
             'unicef', reverse('contacts.contact_delete', args=[self.contact6.pk]))
-        self.assertLoginRedirect(
-            response, 'unicef', '/contact/delete/%d/' % self.contact6.pk)
+        self.assertEqual(response.status_code, 404)
         self.assertTrue(Contact.objects.get(pk=self.contact6.pk).is_active)
 
         # log in as user
@@ -195,5 +194,5 @@ class ContactCRUDLTest(TracProDataTest):
         # try to delete contact from region we don't have access to
         response = self.url_post(
             'unicef', reverse('contacts.contact_delete', args=[self.contact5.pk]))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
         self.assertTrue(Contact.objects.get(pk=self.contact5.pk).is_active)

--- a/tracpro/contacts/tests/test_views.py
+++ b/tracpro/contacts/tests/test_views.py
@@ -26,16 +26,22 @@ class ContactCRUDLTest(TracProDataTest):
         # submit with no fields entered
         response = self.url_post('unicef', url, dict())
         self.assertEqual(response.status_code, 200)
+        form = response.context['form']
+        self.assertEqual(len(form.errors), 4, form.errors)
         self.assertFormError(response, 'form', 'name', 'This field is required.')
         self.assertFormError(response, 'form', 'urn', 'This field is required.')
         self.assertFormError(response, 'form', 'region', 'This field is required.')
+        self.assertFormError(response, 'form', 'group', 'This field is required.')
 
         # submit again with all fields
-        data = dict(
-            name="Mo Polls", urn_0="tel", urn_1="5678",
-            region=self.region1.pk, group=self.group1.pk,
-            language='eng')
-        response = self.url_post('unicef', url, data)
+        response = self.url_post('unicef', url, {
+            'name': "Mo Polls",
+            'urn_0': "tel",
+            'urn_1': "5678",
+            'region': self.region1.pk,
+            'group': self.group1.pk,
+            'language': 'eng',
+        })
         self.assertEqual(response.status_code, 302)
 
         # check new contact and profile
@@ -49,19 +55,25 @@ class ContactCRUDLTest(TracProDataTest):
         self.login(self.user1)
 
         # try to create contact in region we don't have access to
-        data = dict(
-            name="Mo Polls II", urn_0="tel", urn_1="5678",
-            region=self.region3.pk, group=self.group1.pk)
-        response = self.url_post('unicef', url, data)
+        response = self.url_post('unicef', url, {
+            'name': "Mo Polls II",
+            'urn_0': "tel",
+            'urn_1': "5678",
+            'region': self.region3.pk,
+            'group': self.group1.pk,
+        })
         self.assertFormError(response, 'form', 'region',
                              "Select a valid choice. That choice is not one "
                              "of the available choices.")
 
         # try again but this time in a region we do have access to
-        data = dict(
-            name="Mo Polls II", urn_0="tel", urn_1="5678",
-            region=self.region1.pk, group=self.group1.pk)
-        response = self.url_post('unicef', url, data)
+        response = self.url_post('unicef', url, {
+            'name': "Mo Polls II",
+            'urn_0': "tel",
+            'urn_1': "5678",
+            'region': self.region1.pk,
+            'group': self.group1.pk,
+        })
         self.assertEqual(response.status_code, 302)
 
         # test ajax querying for languages
@@ -89,10 +101,14 @@ class ContactCRUDLTest(TracProDataTest):
         response = self.url_get('unicef', url)
         self.assertEqual(response.status_code, 200)
 
-        data = dict(name="Morris", urn_0="tel", urn_1="6789",
-                    region=self.region1.pk, group=self.group2.pk,
-                    language='kin')
-        response = self.url_post('unicef', url, data)
+        response = self.url_post('unicef', url, {
+            'name': "Morris",
+            'urn_0': "tel",
+            'urn_1': "6789",
+            'region': self.region1.pk,
+            'group': self.group2.pk,
+            'language': 'kin',
+        })
         self.assertEqual(response.status_code, 302)
 
         # check updated contact and profile

--- a/tracpro/contacts/tests/test_views.py
+++ b/tracpro/contacts/tests/test_views.py
@@ -34,7 +34,7 @@ class ContactCRUDLTest(TracProDataTest):
         data = dict(
             name="Mo Polls", urn_0="tel", urn_1="5678",
             region=self.region1.pk, group=self.group1.pk,
-            facility_code='FC678', language='eng')
+            language='eng')
         response = self.url_post('unicef', url, data)
         self.assertEqual(response.status_code, 302)
 
@@ -43,7 +43,6 @@ class ContactCRUDLTest(TracProDataTest):
         self.assertEqual(contact.name, "Mo Polls")
         self.assertEqual(contact.region, self.region1)
         self.assertEqual(contact.group, self.group1)
-        self.assertEqual(contact.facility_code, 'FC678')
         self.assertEqual(contact.language, 'eng')
 
         # log in as a user
@@ -92,7 +91,7 @@ class ContactCRUDLTest(TracProDataTest):
 
         data = dict(name="Morris", urn_0="tel", urn_1="6789",
                     region=self.region1.pk, group=self.group2.pk,
-                    facility_code='FC678', language='kin')
+                    language='kin')
         response = self.url_post('unicef', url, data)
         self.assertEqual(response.status_code, 302)
 
@@ -102,7 +101,6 @@ class ContactCRUDLTest(TracProDataTest):
         self.assertEqual(contact.urn, 'tel:6789')
         self.assertEqual(contact.region, self.region1)
         self.assertEqual(contact.group, self.group2)
-        self.assertEqual(contact.facility_code, 'FC678')
         self.assertEqual(contact.language, 'kin')
 
         # try to update contact in a region we don't have access to

--- a/tracpro/contacts/views.py
+++ b/tracpro/contacts/views.py
@@ -82,11 +82,10 @@ class ContactCRUDL(SmartCRUDL):
             initial['region'] = self.request.region
             return initial
 
-        def save(self, obj):
-            org = self.request.user.get_org()
-            self.object = Contact.create(
-                org, self.request.user, obj.name, obj.urn, obj.region,
-                obj.group, obj.facility_code, obj.language)
+        def post_save(self, obj):
+            obj = super(ContactCRUDL.Create, self).post_save(obj)
+            obj.push(ChangeType.created)
+            return obj
 
     class Update(OrgObjPermsMixin, ContactFormMixin, SmartUpdateView):
         fields = ('name', 'urn', 'region', 'group', 'facility_code', 'language')

--- a/tracpro/contacts/views.py
+++ b/tracpro/contacts/views.py
@@ -75,7 +75,7 @@ class ContactCRUDL(SmartCRUDL):
             return obj.get_urn()[1]  # TODO indicate different urn types with icon?
 
     class Create(OrgPermsMixin, ContactFormMixin, ContactBase, SmartCreateView):
-        fields = ('name', 'urn', 'region', 'group', 'facility_code', 'language')
+        fields = ('name', 'urn', 'region', 'group', 'language')
         form_class = ContactForm
 
         def derive_initial(self):
@@ -89,7 +89,7 @@ class ContactCRUDL(SmartCRUDL):
             return obj
 
     class Update(OrgObjPermsMixin, ContactFormMixin, ContactBase, SmartUpdateView):
-        fields = ('name', 'urn', 'region', 'group', 'facility_code', 'language')
+        fields = ('name', 'urn', 'region', 'group', 'language')
         form_class = ContactForm
 
         def post_save(self, obj):
@@ -100,10 +100,10 @@ class ContactCRUDL(SmartCRUDL):
     class Read(OrgObjPermsMixin, ContactFieldsMixin, ContactBase, SmartReadView):
 
         def derive_fields(self):
-            fields = ['urn', 'region', 'group', 'facility_code', 'language',
-                      'last_response']
+            fields = ['urn', 'region', 'group', 'language', 'last_response']
             if self.object.created_by_id:
                 fields.append('created_by')
+
             return fields
 
         def get_last_response(self, obj):

--- a/tracpro/contacts/views.py
+++ b/tracpro/contacts/views.py
@@ -8,9 +8,7 @@ from dash.orgs.views import OrgPermsMixin, OrgObjPermsMixin
 from dash.utils import get_obj_cacheable
 from dash.utils.sync import ChangeType
 
-from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect, JsonResponse
+from django.http import JsonResponse
 from django.utils.translation import ugettext_lazy as _
 
 from smartmin.users.views import (
@@ -194,14 +192,6 @@ class ContactCRUDL(SmartCRUDL):
                 qs = qs.filter(region__in=self.request.data_regions)
             return qs
 
-    class Delete(OrgObjPermsMixin, SmartDeleteView):
+    class Delete(OrgObjPermsMixin, ContactBase, SmartDeleteView):
         cancel_url = '@contacts.contact_list'
-
-        def post(self, request, *args, **kwargs):
-            self.object = self.get_object()
-            if self.request.user.has_region_access(self.object.region):
-                self.pre_delete(self.object)
-                self.object.release()
-                return HttpResponseRedirect(reverse('contacts.contact_list'))
-            else:
-                raise PermissionDenied()
+        redirect_url = '@contacts.contact_list'

--- a/tracpro/contacts/views.py
+++ b/tracpro/contacts/views.py
@@ -75,7 +75,6 @@ class ContactCRUDL(SmartCRUDL):
             return obj.get_urn()[1]  # TODO indicate different urn types with icon?
 
     class Create(OrgPermsMixin, ContactFormMixin, ContactBase, SmartCreateView):
-        fields = ('name', 'urn', 'region', 'group', 'language')
         form_class = ContactForm
 
         def derive_initial(self):
@@ -89,7 +88,6 @@ class ContactCRUDL(SmartCRUDL):
             return obj
 
     class Update(OrgObjPermsMixin, ContactFormMixin, ContactBase, SmartUpdateView):
-        fields = ('name', 'urn', 'region', 'group', 'language')
         form_class = ContactForm
 
         def post_save(self, obj):

--- a/tracpro/contacts/views.py
+++ b/tracpro/contacts/views.py
@@ -82,11 +82,6 @@ class ContactCRUDL(SmartCRUDL):
             initial['region'] = self.request.region
             return initial
 
-        def post_save(self, obj):
-            obj = super(ContactCRUDL.Create, self).post_save(obj)
-            obj.push(ChangeType.created)
-            return obj
-
     class Update(OrgObjPermsMixin, ContactFormMixin, ContactBase, SmartUpdateView):
         form_class = ContactForm
 

--- a/tracpro/orgs_ext/apps.py
+++ b/tracpro/orgs_ext/apps.py
@@ -16,12 +16,6 @@ class DashOrgConfig(AppConfig):
 
         Org = self.get_model('Org')
 
-        def _org_clean(org):
-            """Set a default facility code."""
-            super(org.__class__, org).clean()
-            if not org.facility_code_field:
-                org.facility_code_field = 'facility_code'
-
         def _org_get_task_result(org, task_type):
             cache_key = Org.LAST_TASK_CACHE_KEY % (org.pk, task_type.name)
             result = cache.get(cache_key)
@@ -34,7 +28,6 @@ class DashOrgConfig(AppConfig):
         Org.add_to_class('LAST_TASK_CACHE_KEY', 'org:%d:task_result:%s')
         Org.add_to_class('LAST_TASK_CACHE_TTL', 60 * 60 * 24 * 7)  # 1 week
 
-        Org.add_to_class('clean', _org_clean)
         Org.add_to_class('get_task_result', _org_get_task_result)
         Org.add_to_class('set_task_result', _org_set_task_result)
 
@@ -42,5 +35,3 @@ class DashOrgConfig(AppConfig):
         # allow config attributes to be set as if they were normal attributes.
         Org.add_to_class('available_languages',
                          OrgConfigField("available_languages"))
-        Org.add_to_class('facility_code_field',
-                         OrgConfigField("facility_code_field"))

--- a/tracpro/orgs_ext/apps.py
+++ b/tracpro/orgs_ext/apps.py
@@ -12,6 +12,8 @@ class DashOrgConfig(AppConfig):
 
     def ready(self):
         """Monkey patching for the orgs.Org class."""
+        from . import signals  # noqa
+
         Org = self.get_model('Org')
 
         def _org_clean(org):

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -72,23 +72,3 @@ class OrgExtForm(OrgForm):
             self.instance._visible_data_fields = self.cleaned_data.get('contact_fields')
 
         return super(OrgExtForm, self).save(*args, **kwargs)
-
-
-class SimpleOrgEditForm(OrgForm):
-    facility_code_field = forms.ChoiceField(
-        choices=(), label=_("Facility code field"),
-        help_text=_("Contact field to use as the facility code."))
-
-    class Meta(OrgForm.Meta):
-        fields = ('name', 'timezone')
-
-    def __init__(self, *args, **kwargs):
-        super(SimpleOrgEditForm, self).__init__(*args, **kwargs)
-        field_choices = [(f.key, '{} ({})'.format(f.label, f.key))
-                         for f in self.instance.get_temba_client().get_fields()]
-        self.fields['facility_code_field'].choices = field_choices
-        self.fields['facility_code_field'].initial = self.instance.facility_code_field
-
-    def save(self, *args, **kwargs):
-        self.instance.facility_code_field = self.cleaned_data['facility_code_field']
-        return super(SimpleOrgEditForm, self).save(*args, **kwargs)

--- a/tracpro/orgs_ext/signals.py
+++ b/tracpro/orgs_ext/signals.py
@@ -1,0 +1,13 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from dash.orgs.models import Org
+
+from tracpro.contacts.models import DataField
+
+
+@receiver(post_save, sender=Org)
+def set_visible_data_fields(sender, instance, **kwargs):
+    """Hook to update the visible DataFields for an org."""
+    if hasattr(instance, '_visible_data_fields'):
+        DataField.objects.set_active_for_org(instance, instance._visible_data_fields)

--- a/tracpro/orgs_ext/tests/test_forms.py
+++ b/tracpro/orgs_ext/tests/test_forms.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import mock
+
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.test import override_settings, TestCase
 
@@ -8,6 +10,7 @@ from tracpro.test import factories
 from .. import forms
 
 
+@mock.patch('tracpro.contacts.models.DataFieldManager.sync')
 @override_settings(LANGUAGES=[
     ('en', 'English'),
     ('es', 'Spanish'),
@@ -30,18 +33,18 @@ class TestOrgExtForm(TestCase):
             'administrators': [self.user.pk],
         }
 
-    def test_available_languages_initial_for_create(self):
+    def test_available_languages_initial_for_create(self, mock_sync):
         """Available languages should default to empty list when creating an org."""
         form = self.form_class(instance=None)
         self.assertEqual(form.fields['available_languages'].initial, [])
 
-    def test_available_languages_initial_for_update(self):
+    def test_available_languages_initial_for_update(self, mock_sync):
         """Available languages should be set from the instance to update."""
         org = factories.Org(available_languages=['en', 'es'])
         form = self.form_class(instance=org)
         self.assertEqual(form.fields['available_languages'].initial, ['en', 'es'])
 
-    def test_default_language_required_for_create(self):
+    def test_default_language_required_for_create(self, mock_sync):
         """Form should require a default language for new orgs."""
         self.data.pop('language')
         form = self.form_class(data=self.data, instance=None)
@@ -51,7 +54,7 @@ class TestOrgExtForm(TestCase):
         self.assertEqual(form.errors['language'],
                          ['This field is required.'])
 
-    def test_default_language_required_for_update(self):
+    def test_default_language_required_for_update(self, mock_sync):
         """Form should require a default language when updating an org."""
         self.data.pop('language')
         form = self.form_class(data=self.data, instance=factories.Org())
@@ -61,7 +64,7 @@ class TestOrgExtForm(TestCase):
         self.assertEqual(form.errors['language'],
                          ['This field is required.'])
 
-    def test_available_languages_required_for_create(self):
+    def test_available_languages_required_for_create(self, mock_sync):
         """Form should require available languages for new orgs."""
         self.data.pop('available_languages')
         form = self.form_class(data=self.data, instance=None)
@@ -71,7 +74,7 @@ class TestOrgExtForm(TestCase):
         self.assertEqual(form.errors['available_languages'],
                          ['This field is required.'])
 
-    def test_available_languages_required_for_update(self):
+    def test_available_languages_required_for_update(self, mock_sync):
         """Form should require available languages for new orgs."""
         self.data.pop('available_languages')
         form = self.form_class(data=self.data, instance=factories.Org())
@@ -81,7 +84,7 @@ class TestOrgExtForm(TestCase):
         self.assertEqual(form.errors['available_languages'],
                          ['This field is required.'])
 
-    def test_default_language_not_in_available_languages(self):
+    def test_default_language_not_in_available_languages(self, mock_sync):
         """Form should require that default language is in available languages."""
         self.data['language'] = 'fr'
         form = self.form_class(data=self.data)
@@ -93,7 +96,7 @@ class TestOrgExtForm(TestCase):
                           'available for this organization.'],
                          form.errors)
 
-    def test_available_languages_no_change(self):
+    def test_available_languages_no_change(self, mock_sync):
         """Form should allow available languages to remain unchanged."""
         org = factories.Org(
             available_languages=['en', 'es'],
@@ -106,7 +109,7 @@ class TestOrgExtForm(TestCase):
         self.assertEqual(org.available_languages, ['en', 'es'])
         self.assertEqual(org.language, 'en')
 
-    def test_add_available_languages(self):
+    def test_add_available_languages(self, mock_sync):
         """Form should allow addition of available language(s)."""
         org = factories.Org(
             available_languages=['en', 'es'],
@@ -120,7 +123,7 @@ class TestOrgExtForm(TestCase):
         self.assertEqual(org.available_languages, ['en', 'es', 'fr'])
         self.assertEqual(org.language, 'en')
 
-    def test_remove_available_languages(self):
+    def test_remove_available_languages(self, mock_sync):
         """Form should allow removal of available language(s)."""
         org = factories.Org(
             available_languages=['en', 'es'],
@@ -134,7 +137,7 @@ class TestOrgExtForm(TestCase):
         self.assertEqual(org.available_languages, ['en'])
         self.assertEqual(org.language, 'en')
 
-    def test_remove_default_from_available(self):
+    def test_remove_default_from_available(self, mock_sync):
         """Form should error if default language is removed from available languages."""
         org = factories.Org(
             available_languages=['en', 'es'],

--- a/tracpro/orgs_ext/utils.py
+++ b/tracpro/orgs_ext/utils.py
@@ -60,9 +60,18 @@ def run_org_task(org, task):
     try:
         return task(org.pk)
     except TembaAPIError as e:
-        if isinstance(e.caused_by, HTTPError):
-            if e.caused_by.response.status_code == 403:
-                logger.warning(
-                    "API token for {} is invalid.".format(org), exc_info=True)
-                return None
+        if caused_by_bad_api_key(e):
+            logger.warning(
+                "API token for {} is invalid.".format(org), exc_info=True)
+            return None
         raise
+
+
+def caused_by_bad_api_key(exception):
+    """Return whether the exception was likely caused by a bad API key."""
+    if isinstance(exception, TembaAPIError):
+        if isinstance(exception.caused_by, HTTPError):
+            response = exception.caused_by.response
+            if response and response.status_code == 403:
+                return True
+    return False

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -28,8 +28,8 @@ class OrgExtCRUDL(OrgCRUDL):
     class Update(OrgCRUDL.Update):
         form_class = forms.OrgExtForm
         fields = ('is_active', 'name', 'available_languages', 'language',
-                  'timezone', 'subdomain', 'api_token', 'logo',
-                  'administrators')
+                  'contact_fields', 'timezone', 'subdomain', 'api_token',
+                  'logo', 'administrators')
 
     class Home(OrgCRUDL.Home):
         fields = ('name', 'timezone', 'facility_code_field', 'api_token',

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -32,8 +32,8 @@ class OrgExtCRUDL(OrgCRUDL):
                   'logo', 'administrators')
 
     class Home(OrgCRUDL.Home):
-        fields = ('name', 'timezone', 'facility_code_field', 'api_token',
-                  'last_contact_sync', 'last_flow_run_fetch')
+        fields = ('name', 'timezone', 'api_token', 'last_contact_sync',
+                  'last_flow_run_fetch')
         field_config = {
             'api_token': {
                 'label': _("RapidPro API Token"),
@@ -66,8 +66,8 @@ class OrgExtCRUDL(OrgCRUDL):
                 return None
 
     class Edit(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-        fields = ('name', 'timezone', 'facility_code_field')
-        form_class = forms.SimpleOrgEditForm
+        fields = ('name', 'timezone')
+        form_class = forms.OrgExtForm
         permission = 'orgs.org_edit'
         success_url = '@orgs_ext.org_home'
         title = _("Edit My Organization")

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -246,17 +246,22 @@ CELERYBEAT_SCHEDULE = {
     'sync-contacts': {
         'task': 'tracpro.contacts.tasks.sync_all_contacts',
         'schedule': datetime.timedelta(minutes=5),
-        'args': ()
+        'args': (),
+    },
+    'sync-fields': {
+        'task': 'tracpro.contacts.tasks.sync_all_fields',
+        'schedule': datetime.timedelta(days=1),
+        'args': (),
     },
     'fetch-runs': {
         'task': 'tracpro.polls.tasks.fetch_all_runs',
         'schedule': datetime.timedelta(minutes=5),
-        'args': ()
+        'args': (),
     },
     'fetch-inbox-messages': {
         'task': 'tracpro.msgs.tasks.fetch_all_inbox_messages',
         'schedule': datetime.timedelta(minutes=5),
-        'args': ()
+        'args': (),
     }
 }
 

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -314,13 +314,6 @@ GROUP_PERMISSIONS = {
 
 ORG_CONFIG_FIELDS = [
     {
-        'name': 'facility_code_field',
-        'field': {
-            'help_text': _("Contact field to use as the facility code"),
-            'required': True,
-        },
-    },
-    {
         'name': 'available_languages',
         'field': {
             'help_text': _("The languages used by administrators in your organization"),

--- a/tracpro/test/cases.py
+++ b/tracpro/test/cases.py
@@ -12,7 +12,6 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-from tracpro.contacts.models import Contact
 from tracpro.groups.models import Group, Region
 from tracpro.polls.models import Question
 
@@ -59,8 +58,9 @@ class TracProTest(TestCase):
 
     def create_contact(self, org, name, urn, region, group, uuid):
         user = org.administrators.first()
-        return Contact.create(
-            org, user, name, urn, region, group, 'FC123', 'eng', uuid)
+        return factories.Contact(
+            org=org, name=name, urn=urn, region=region, group=group, uuid=uuid,
+            facility_code='FC123', language='eng', created_by=user, modified_by=user)
 
     def login(self, user):
         result = self.client.login(username=user.username, password=user.username)

--- a/tracpro/test/cases.py
+++ b/tracpro/test/cases.py
@@ -36,7 +36,6 @@ class TracProTest(TestCase):
             name=name, timezone=timezone, subdomain=subdomain,
             api_token=str(uuid4()), created_by=self.superuser,
             modified_by=self.superuser)
-        org.set_config('facility_code_field', 'facility_code')
         return org
 
     def create_region(self, org, name, uuid):
@@ -60,7 +59,7 @@ class TracProTest(TestCase):
         user = org.administrators.first()
         return factories.Contact(
             org=org, name=name, urn=urn, region=region, group=group, uuid=uuid,
-            facility_code='FC123', language='eng', created_by=user, modified_by=user)
+            language='eng', created_by=user, modified_by=user)
 
     def login(self, user):
         result = self.client.login(username=user.username, password=user.username)


### PR DESCRIPTION
* Administrator can use the org update page to choose which available fields (synced from RapidPro) should be visible on Tracpro.
* Available Fields are synced daily, as well as each time that a user loads the Org update page.
* Contact field values are synced to/from RapidPro.
* Chosen fields are visible on the Contact detail page.
* Chosen fields are editable on the Contact create/update pages.
* `Org.facility_code` has been removed; a migration adds this as an active data field on each org.

Modular commits to aid review. More tests forthcoming.