### PR TITLE
BaselineTerm name modifications

### DIFF
--- a/tracpro/baseline/forms.py
+++ b/tracpro/baseline/forms.py
@@ -45,7 +45,7 @@ class BaselineTermForm(forms.ModelForm):
         follow_up_question = cleaned_data.get("follow_up_question")
         if baseline_question and follow_up_question and baseline_question == follow_up_question:
             raise forms.ValidationError(
-                _("Baseline and observation questions should be different."))
+                _("Baseline and follow up questions should be different."))
 
         return cleaned_data
 
@@ -62,17 +62,17 @@ class SpoofDataForm(forms.Form):
         help_text=_("Select contacts for this set of spoofed data."))
     start_date = forms.DateField(
         help_text=_("Baseline poll data will be submitted on this date. "
-                    "Observation data will start on this date."))
+                    "Follow up data will start on this date."))
     end_date = forms.DateField(
-        help_text=_("Observation data will end on this date. "))
+        help_text=_("Follow up data will end on this date. "))
     baseline_question = QuestionModelChoiceField(
         queryset=Question.objects.all().order_by('poll__name', 'text'),
         help_text=_("Select a baseline question which will have numeric "
                     "answers only."))
     follow_up_question = QuestionModelChoiceField(
-        label=_("Observation Question"),
+        label=_("Follow Up Question"),
         queryset=Question.objects.all().order_by('poll__name', 'text'),
-        help_text=_("Select an observation up question which will have "
+        help_text=_("Select a follow up question which will have "
                     "numeric answers only."))
     baseline_minimum = forms.IntegerField(
         help_text=_("A baseline answer will be created for each contact "
@@ -81,12 +81,12 @@ class SpoofDataForm(forms.Form):
         help_text=_("A baseline answer will be created for each contact "
                     "within the minimum/maximum range."))
     follow_up_minimum = forms.IntegerField(
-        label=_("Observation Minimum"),
-        help_text=_("Observation answers will be created for each contact "
+        label=_("Follow Up Minimum"),
+        help_text=_("Follow up answers will be created for each contact "
                     "within the minimum/maximum range."))
     follow_up_maximum = forms.IntegerField(
-        label=_("Observation Maximum"),
-        help_text=_("Observation answers will be created for each contact "
+        label=_("Follow Up Maximum"),
+        help_text=_("Follow up answers will be created for each contact "
                     "within the minimum/maximum range."))
 
     def __init__(self, *args, **kwargs):
@@ -114,7 +114,7 @@ class SpoofDataForm(forms.Form):
         follow_up_question = cleaned_data.get("follow_up_question")
         if baseline_question and follow_up_question and baseline_question == follow_up_question:
             raise forms.ValidationError(
-                _("Baseline and observation questions should be different."))
+                _("Baseline and follow up questions should be different."))
 
         baseline_minimum = cleaned_data.get("baseline_minimum")
         baseline_maximum = cleaned_data.get("baseline_maximum")
@@ -126,6 +126,6 @@ class SpoofDataForm(forms.Form):
         follow_up_maximum = cleaned_data.get("follow_up_maximum")
         if follow_up_minimum and follow_up_maximum and follow_up_minimum > follow_up_maximum:
             raise forms.ValidationError(
-                _("Observation maximum should exceed or equal minimum."))
+                _("Follow up maximum should exceed or equal minimum."))
 
         return cleaned_data

--- a/tracpro/baseline/migrations/0008_rename_observation_to_follow_up.py
+++ b/tracpro/baseline/migrations/0008_rename_observation_to_follow_up.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import smart_selects.db_fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('baseline', '0007_follow_up_to_observation'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='baselineterm',
+            options={'verbose_name': 'Indictator'},
+        ),
+        migrations.AlterField(
+            model_name='baselineterm',
+            name='follow_up_poll',
+            field=models.ForeignKey(related_name='+', verbose_name='Follow Up Poll', to='polls.Poll'),
+        ),
+        migrations.AlterField(
+            model_name='baselineterm',
+            name='follow_up_question',
+            field=smart_selects.db_fields.ChainedForeignKey(chained_model_field=b'poll', related_name='+', chained_field=b'follow_up_poll', verbose_name='Follow Up Question', auto_choose=True, to='polls.Question', help_text='Follow up poll responses over time to compare to the baseline values.'),
+        ),
+    ]

--- a/tracpro/baseline/models.py
+++ b/tracpro/baseline/models.py
@@ -38,9 +38,9 @@ class BaselineTerm(models.Model):
     )
 
     follow_up_poll = models.ForeignKey(
-        Poll, verbose_name=_("Observation Poll"), related_name="+")
+        Poll, verbose_name=_("Follow Up Poll"), related_name="+")
     follow_up_question = ChainedForeignKey(
-        Question, verbose_name=_("Observation Question"), related_name="+",
+        Question, verbose_name=_("Follow Up Question"), related_name="+",
         auto_choose=True,
         chained_field='follow_up_poll', chained_model_field='poll',
         help_text=_("Follow up poll responses over time to compare to the "
@@ -50,6 +50,9 @@ class BaselineTerm(models.Model):
     y_axis_title = models.CharField(
         max_length=255, blank=True, default="",
         help_text=_("The title for the y axis of the chart."))
+
+    class Meta:
+        verbose_name = _("Indictator")
 
     @classmethod
     def get_all(cls, org):

--- a/tracpro/baseline/tests/test_forms.py
+++ b/tracpro/baseline/tests/test_forms.py
@@ -58,7 +58,7 @@ class BaselineTermFormTest(TracProDataTest):
         self.assertEqual(len(form.errors), 1, form.errors)
         self.assertTrue(NON_FIELD_ERRORS in form.errors, form.errors)
         self.assertEqual(form.errors[NON_FIELD_ERRORS],
-                         ['Baseline and observation questions should be different.'],
+                         ['Baseline and follow up questions should be different.'],
                          form.errors)
 
 
@@ -107,7 +107,7 @@ class SpoofDataFormTest(TracProDataTest):
         self.assertEqual(len(form.errors), 1, form.errors)
         self.assertTrue(NON_FIELD_ERRORS in form.errors, form.errors)
         self.assertEqual(form.errors[NON_FIELD_ERRORS],
-                         ['Baseline and observation questions should be different.'],
+                         ['Baseline and follow up questions should be different.'],
                          form.errors)
 
     def test_min_max_baseline(self):
@@ -131,5 +131,5 @@ class SpoofDataFormTest(TracProDataTest):
         self.assertEqual(len(form.errors), 1, form.errors)
         self.assertTrue(NON_FIELD_ERRORS in form.errors, form.errors)
         self.assertEqual(form.errors[NON_FIELD_ERRORS],
-                         ['Observation maximum should exceed or equal minimum.'],
+                         ['Follow up maximum should exceed or equal minimum.'],
                          form.errors)

--- a/tracpro/templates/baseline/baselineterm_chart.html
+++ b/tracpro/templates/baseline/baselineterm_chart.html
@@ -7,7 +7,7 @@ $(function () {
             text: '{{ baselineterm.name|escapejs }}'
         },
         subtitle: {
-            text: 'Baseline: {{ baselineterm.baseline_question|escapejs }}, Observations: {{ baselineterm.follow_up_question|escapejs }}'
+            text: 'Baseline: {{ baselineterm.baseline_question|escapejs }}, Follow Ups: {{ baselineterm.follow_up_question|escapejs }}'
         },
         xAxis: {
             categories: [
@@ -39,10 +39,10 @@ $(function () {
                 data: {{ baseline_list }}
             {% endif %}
         },
-        // Observation Data
+        // Follow Up Data
         {
             type: 'area',
-            name: 'Observations',
+            name: 'Follow Up',
             data: {{ follow_up_list }}
         }
         ]

--- a/tracpro/templates/baseline/baselineterm_read.html
+++ b/tracpro/templates/baseline/baselineterm_read.html
@@ -31,7 +31,7 @@
     <td class="read-value">{{ baselineterm.baseline_poll }} / {{ baselineterm.baseline_question }}</td>
   </tr>
   <tr class="read">
-    <td class="read-label">Observation Poll / Question</td>
+    <td class="read-label">Follow Up Poll / Question</td>
     <td class="read-value">{{ baselineterm.follow_up_poll }} / {{ baselineterm.follow_up_question }}</td>
   </tr>
 
@@ -50,15 +50,15 @@
     <td class="read-value">{{ baseline_response_rate }}%</td>
   </tr>
   <tr class="read">
-    <td class="read-label">Observation Poll / Question</td>
+    <td class="read-label">Follow Up Poll / Question</td>
     <td class="read-value">{{ follow_up_mean }}</td>
   </tr>
   <tr class="read">
-    <td class="read-label">Observation Standard Deviation</td>
+    <td class="read-label">Follow Up Standard Deviation</td>
     <td class="read-value">{{ follow_up_std }}</td>
   </tr>
   <tr class="read">
-    <td class="read-label">Observation Response Rate</td>
+    <td class="read-label">Follow Up Response Rate</td>
     <td class="read-value">{{ follow_up_response_rate }}%</td>
   </tr>
   {% endif %}


### PR DESCRIPTION
Based on the discussion in our recent check-in, `BaselineTerms` should be called `Indicators` or `Recent Indicators` and "observation data" should be called "follow up data". 