### PR TITLE
Fix unicode error

### DIFF
--- a/tracpro/contacts/forms.py
+++ b/tracpro/contacts/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
+from django.utils.text import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from dash.utils.sync import ChangeType
@@ -347,4 +348,4 @@ class ContactField(models.Model):
         elif isinstance(value, datetime.datetime):
             self.value = value.isoformat()
         else:
-            self.value = str(value)
+            self.value = force_text(value)

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -5,12 +5,11 @@ from decimal import Decimal, InvalidOperation
 import logging
 from uuid import uuid4
 
-from dateutil.parser import parse
-
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.dateparse import parse_datetime
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.text import force_text
 from django.utils.translation import ugettext_lazy as _
@@ -323,13 +322,7 @@ class ContactField(models.Model):
         if self.value is None:
             return None
         elif self.field.value_type == DataField.TYPE_DATETIME:
-            try:
-                return parse(self.value)
-            except ValueError:
-                logger.warning(
-                    "Unable to parse {} value for {} as datetime: {}".format(
-                        self.value, self.contact, self.value))
-                return None
+            return parse_datetime(self.value)
         elif self.field.value_type == DataField.TYPE_NUMERIC:
             try:
                 return Decimal(self.value)

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -339,6 +339,6 @@ class ContactField(models.Model):
         if value is None:
             self.value = None
         elif isinstance(value, datetime.datetime):
-            self.value = value.isoformat()
+            self.value = unicode(value.isoformat())
         else:
             self.value = force_text(value)

--- a/tracpro/contacts/signals.py
+++ b/tracpro/contacts/signals.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 

--- a/tracpro/contacts/tests/factories.py
+++ b/tracpro/contacts/tests/factories.py
@@ -9,7 +9,7 @@ from tracpro.test import factory_utils
 from .. import models
 
 
-__all__ = ['Contact']
+__all__ = ['Contact', 'TwitterContact', 'PhoneContact', 'DataField', 'ContactField']
 
 
 class Contact(factory_utils.SmartModelFactory):
@@ -18,7 +18,7 @@ class Contact(factory_utils.SmartModelFactory):
     urn = factory.Sequence(lambda n: random.choice(("twitter:contact", "tel:123")) + str(n))
 
     class Meta:
-        model = models.Contact
+        model = 'contacts.Contact'
 
     @factory.lazy_attribute
     def region(self):
@@ -32,3 +32,20 @@ class TwitterContact(Contact):
 
 class PhoneContact(Contact):
     urn = factory.Sequence(lambda n: "tel:123" + str(n))
+
+
+class DataField(factory.django.DjangoModelFactory):
+    org = factory.SubFactory("tracpro.test.factories.Org")
+    key = factory.fuzzy.FuzzyText()
+    value_type = models.DataField.TYPE_TEXT
+
+    class Meta:
+        model = 'contacts.DataField'
+
+
+class ContactField(factory.django.DjangoModelFactory):
+    contact = factory.SubFactory("tracpro.test.factories.Contact")
+    field = factory.SubFactory("tracpro.test.factories.DataField")
+
+    class Meta:
+        model = 'contacts.ContactField'

--- a/tracpro/contacts/tests/test_models.py
+++ b/tracpro/contacts/tests/test_models.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
+import datetime
+from decimal import Decimal
+
 import mock
+import pytz
 
 from temba_client.types import Contact as TembaContact
 
@@ -10,9 +14,9 @@ from dash.utils.sync import ChangeType
 
 from tracpro.polls.models import Response
 from tracpro.test import factories
-from tracpro.test.cases import TracProDataTest
+from tracpro.test.cases import TracProDataTest, TracProTest
 
-from ..models import Contact
+from .. import models
 
 
 class ContactTest(TracProDataTest):
@@ -70,11 +74,11 @@ class ContactTest(TracProDataTest):
             fields={},
             language='eng', modified_on=timezone.now())
         # get locally
-        contact = Contact.get_or_fetch(self.unicef, 'C-001')
+        contact = models.Contact.get_or_fetch(self.unicef, 'C-001')
         self.assertEqual(contact.name, "Ann")
 
         # fetch remotely
-        contact = Contact.get_or_fetch(self.unicef, 'C-009')
+        contact = models.Contact.get_or_fetch(self.unicef, 'C-009')
         self.assertEqual(contact.name, "Mo Polls")
 
     def test_kwargs_from_temba(self):
@@ -91,7 +95,7 @@ class ContactTest(TracProDataTest):
             modified_on=modified_date,
         )
 
-        kwargs = Contact.kwargs_from_temba(self.unicef, temba_contact)
+        kwargs = models.Contact.kwargs_from_temba(self.unicef, temba_contact)
         self.assertDictEqual(kwargs, {
             'uuid': 'C-007',
             'org': self.unicef,
@@ -107,7 +111,7 @@ class ContactTest(TracProDataTest):
         })
 
         # try creating contact from them
-        Contact.objects.create(**kwargs)
+        models.Contact.objects.create(**kwargs)
 
     def test_as_temba(self):
         temba_contact = self.contact1.as_temba()
@@ -118,8 +122,8 @@ class ContactTest(TracProDataTest):
         self.assertEqual(temba_contact.uuid, 'C-001')
 
     def test_by_org(self):
-        self.assertEqual(len(Contact.objects.active().by_org(self.unicef)), 5)
-        self.assertEqual(len(Contact.objects.active().by_org(self.nyaruka)), 1)
+        self.assertEqual(len(models.Contact.objects.active().by_org(self.unicef)), 5)
+        self.assertEqual(len(models.Contact.objects.active().by_org(self.nyaruka)), 1)
 
     def test_get_responses(self):
         date1 = self.datetime(2014, 1, 1, 7, 0)
@@ -157,3 +161,109 @@ class ContactTest(TracProDataTest):
         self.contact1.name = ""
         self.contact1.save()
         self.assertEqual(str(self.contact1), "1234")
+
+
+class TestContactField(TracProTest):
+
+    def _test_get_value(self, value_type, tests):
+        contact_field = factories.ContactField(field__value_type=value_type)
+
+        # get_value() will return None if value is None, regardless of type.
+        contact_field.value = None
+        self.assertEqual(contact_field.get_value(), None)
+
+        # Set the value field directly, then test what get_value() returns.
+        for value, expected in tests:
+            contact_field.value = value
+            self.assertEqual(contact_field.get_value(), expected)
+
+    def test_get_value_text(self):
+        """Value is returned as-is when data field type is textual."""
+        self._test_get_value(models.DataField.TYPE_TEXT, (
+            ("\u2603", "\u2603"),
+            ("hello", "hello"),
+            ("2015-09-15T21:32:56.349186", "2015-09-15T21:32:56.349186"),
+            ("2015-09-15T21:32:56.349186+00:00", "2015-09-15T21:32:56.349186+00:00"),
+            ("1.1", "1.1"),
+            ("1", "1"),
+        ))
+
+    def test_get_value_state(self):
+        """Value is returned as-is when data field type is textual."""
+        self._test_get_value(models.DataField.TYPE_STATE, (
+            ("\u2603", "\u2603"),
+            ("hello", "hello"),
+            ("2015-09-15T21:32:56.349186", "2015-09-15T21:32:56.349186"),
+            ("2015-09-15T21:32:56.349186+00:00", "2015-09-15T21:32:56.349186+00:00"),
+            ("1.1", "1.1"),
+            ("1", "1"),
+        ))
+
+    def test_get_value_district(self):
+        """Value is returned as-is when data field type is textual."""
+        self._test_get_value(models.DataField.TYPE_DISTRICT, (
+            ("\u2603", "\u2603"),
+            ("hello", "hello"),
+            ("2015-09-15T21:32:56.349186", "2015-09-15T21:32:56.349186"),
+            ("2015-09-15T21:32:56.349186+00:00", "2015-09-15T21:32:56.349186+00:00"),
+            ("1.1", "1.1"),
+            ("1", "1"),
+        ))
+
+    def test_get_value_numeric(self):
+        """If value cannot be cast as a Decimal, None is returned."""
+        self._test_get_value(models.DataField.TYPE_NUMERIC, (
+            ("\u2603", None),
+            ("hello", None),
+            ("2015-09-15T21:32:56.349186", None),
+            ("2015-09-15T21:32:56.349186+00:00", None),
+            ("1.1", Decimal("1.1")),
+            ("1", Decimal("1")),
+        ))
+
+    def test_get_value_datetime(self):
+        """If value cannot be parsed as a datetime, None is returned."""
+        self._test_get_value(models.DataField.TYPE_DATETIME, (
+            ("\u2603", None),
+            ("hello", None),
+            ("2015-09-15T21:32:56.349186",
+             datetime.datetime(2015, 9, 15, 21, 32, 56, 349186)),
+            ("2015-09-15T21:32:56.349186+00:00",
+             datetime.datetime(2015, 9, 15, 21, 32, 56, 349186, tzinfo=pytz.UTC)),
+            ("1.1", None),
+            ("1", None),
+        ))
+
+    def test_set_value(self):
+        """set_value() serializes values as unicode."""
+        contact_field = factories.ContactField()
+
+        contact_field.set_value(None)
+        self.assertEqual(contact_field.value, None)
+
+        contact_field.set_value("\u2603")
+        self.assertEqual(contact_field.value, "\u2603")
+
+        contact_field.set_value("hello")
+        self.assertEqual(contact_field.value, "hello")
+
+        contact_field.set_value(datetime.datetime(2015, 9, 15, 21, 32, 56, 349186))
+        self.assertEqual(contact_field.value, "2015-09-15T21:32:56.349186")
+
+        contact_field.set_value(datetime.datetime(2015, 9, 15, 21, 32, 56, 349186, tzinfo=pytz.UTC))
+        self.assertEqual(contact_field.value, "2015-09-15T21:32:56.349186+00:00")
+
+        contact_field.set_value(1.1)
+        self.assertEqual(contact_field.value, "1.1")
+
+        contact_field.set_value(1)
+        self.assertEqual(contact_field.value, "1")
+
+    def test_str(self):
+        """Smoke test for string representation."""
+        contact_field = factories.ContactField(
+            contact__name="Sam",
+            field__label="Data Field",
+            value="hello",
+        )
+        self.assertEqual(str(contact_field), "Sam Data Field: hello")


### PR DESCRIPTION
```
  File "/var/www/tracpro/source/tracpro/contacts/models.py", line 350, in set_value
    self.value = str(value)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2603' in position 0: ordinal not in range(128)
```

* Fixes the above unicode-related error when setting a `ContactField` value
* Change date parser to avoid `"1"` being parsed as `datetime.datetime(2015, 11, 1, 0, 0)`
* Adds tests for `ContactField`