### PR TITLE
Update package version requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,22 +3,22 @@
 -e git+https://github.com/caktus/smartmin.git@master#egg=smartmin-1.8.1
 
 Django==1.8.6
-Pillow==2.9.0
+Pillow==3.0.0
 boto==2.38.0
-django-celery==3.1.16
-  celery==3.1.18
-    billiard==3.3.0.20
-    kombu==3.0.26
-      amqp==1.4.6
+django-celery==3.1.17
+  celery==3.1.19
+    billiard==3.3.0.21
+    kombu==3.0.29
+      amqp==1.4.7
       anyjson==0.3.3
-django-celery-transactions==0.3.1
+django-celery-transactions==0.3.5
 django-compressor==1.5
   django-appconf==1.0.1
 django-digest==1.13
-django-guardian==1.3
+django-guardian==1.3.1
 django-mptt==0.7.4
 django-redis==3.8.4
-  redis==2.10.3
+  redis==2.10.5
 django-rosetta==0.7.6
   microsofttranslator==0.7
   polib==1.0.7
@@ -26,20 +26,20 @@ django-smart-selects==1.1.1
 django-storages==1.1.8
 django-timezones==0.2
 enum34==1.0.4
-  Markdown==2.6.2
+  Markdown==2.6.3
   Pygments==2.0.2
-numpy==1.9.3
-phonenumbers==7.0.7
+numpy==1.10.1
+phonenumbers==7.1.1
 pisa==3.0.33
 psycopg2==2.6.1
 pycountry==1.10
 python-dateutil==2.4.2
-pytz==2015.4
-requests==2.7.0
-six==1.9.0
+pytz==2015.7
+requests==2.8.1
+six==1.10.0
 sorl-thumbnail==12.3
 stop-words==2015.2.23.1
-unicodecsv==0.13.0
+unicodecsv==0.14.1
 wsgiref==0.1.2
 xlrd==0.9.4
 xlwt==1.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/caktus/dash.git@master#egg=dash
 -e git+https://github.com/caktus/smartmin.git@master#egg=smartmin-1.8.1
 
-Django==1.8.4
+Django==1.8.6
 Pillow==2.9.0
 boto==2.38.0
 django-celery==3.1.16

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,6 @@ django-guardian==1.3
 django-mptt==0.7.4
 django-redis==3.8.4
   redis==2.10.3
-django-reversion==1.8.7
 django-rosetta==0.7.6
   microsofttranslator==0.7
   polib==1.0.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 -r tests.txt
 
-django-debug-toolbar==1.3.2
-  sqlparse==0.1.15
+django-debug-toolbar==1.4
+  sqlparse==0.1.18

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,11 +1,12 @@
 -r base.txt
 
-coverage==3.7.1
-factory-boy==2.5.2
-flake8==2.4.1
+coverage==4.0.2
+factory-boy==2.6.0
+  fake-factory==0.5.3
+flake8==2.5.0
   mccabe==0.3.1
   pep8==1.5.7
-  pyflakes==0.8.1
-mock==1.1.3
+  pyflakes==1.0.0
+mock==1.3.0
   funcsigs==0.4
-  pbr==1.3.0
+  pbr==1.8.1

--- a/tracpro/contacts/tests/factories.py
+++ b/tracpro/contacts/tests/factories.py
@@ -1,7 +1,6 @@
 import random
 
 import factory
-import factory.django
 import factory.fuzzy
 
 from tracpro.test import factory_utils

--- a/tracpro/groups/tests/factories.py
+++ b/tracpro/groups/tests/factories.py
@@ -1,5 +1,4 @@
 import factory
-import factory.django
 import factory.fuzzy
 
 from tracpro.test.factory_utils import FuzzyUUID

--- a/tracpro/orgs_ext/tests/factories.py
+++ b/tracpro/orgs_ext/tests/factories.py
@@ -1,5 +1,4 @@
 import factory
-import factory.django
 import factory.fuzzy
 
 from tracpro.test.factory_utils import SmartModelFactory

--- a/tracpro/polls/tests/factories.py
+++ b/tracpro/polls/tests/factories.py
@@ -1,7 +1,6 @@
 import datetime
 
 import factory
-import factory.django
 import factory.fuzzy
 
 from django.utils import timezone

--- a/tracpro/profiles/tests/factories.py
+++ b/tracpro/profiles/tests/factories.py
@@ -1,5 +1,4 @@
 import factory
-import factory.django
 import factory.fuzzy
 
 from tracpro.test.factory_utils import FuzzyEmail

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -58,7 +58,6 @@ INSTALLED_APPS = [
     'djcelery',
     'guardian',
     'mptt',
-    'reversion',
     'sorl.thumbnail',
     'smart_selects',
 
@@ -174,7 +173,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'reversion.middleware.RevisionMiddleware',
     'smartmin.middleware.AjaxRedirect',
     'dash.orgs.middleware.SetOrgMiddleware',
     'tracpro.profiles.middleware.ForcePasswordChangeMiddleware',

--- a/tracpro/test/factory_utils.py
+++ b/tracpro/test/factory_utils.py
@@ -1,7 +1,7 @@
 import uuid
 
+import factory
 import factory.fuzzy
-import factory.django
 
 
 class FuzzyEmail(factory.fuzzy.FuzzyText):


### PR DESCRIPTION
* Update to latest Django security release
* Update all package versions. Notably, the latest Django did not seem to agree with django-celery==3.1.16
* Remove dependency on `django-reversion` since nothing required it and its usage had no effect