### PR TITLE
Editable Question type

### DIFF
--- a/tracpro/baseline/forms.py
+++ b/tracpro/baseline/forms.py
@@ -52,7 +52,7 @@ class BaselineTermForm(forms.ModelForm):
 
 class QuestionModelChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
-        return "%s: %s" % (obj.poll.name, obj.text)
+        return "%s: %s" % (obj.poll.name, obj.name)
 
 
 class SpoofDataForm(forms.Form):

--- a/tracpro/baseline/forms.py
+++ b/tracpro/baseline/forms.py
@@ -28,7 +28,7 @@ class BaselineTermForm(forms.ModelForm):
         super(BaselineTermForm, self).__init__(*args, **kwargs)
 
         if org:
-            polls = Poll.get_all(org).order_by('name')
+            polls = Poll.objects.active().by_org(org).order_by('name')
             self.fields['baseline_poll'].queryset = polls
             self.fields['follow_up_poll'].queryset = polls
 
@@ -97,7 +97,7 @@ class SpoofDataForm(forms.Form):
         if org:
             contacts = Contact.objects.active().by_org(org).order_by('name')
             self.fields['contacts'].queryset = contacts
-            questions = Question.objects.filter(poll__in=Poll.get_all(org))
+            questions = Question.objects.filter(poll__in=Poll.objects.active().by_org(org))
             self.fields['baseline_question'].queryset = questions
             self.fields['follow_up_question'].queryset = questions
 

--- a/tracpro/contacts/migrations/0010_auto_20151111_2239.py
+++ b/tracpro/contacts/migrations/0010_auto_20151111_2239.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='datafield',
             name='show_on_tracpro',
-            field=models.BooleanField(default=False, verbose_name='show_on_tracpro'),
+            field=models.BooleanField(default=False, verbose_name='show on TracPro'),
         ),
         migrations.AlterField(
             model_name='datafield',

--- a/tracpro/contacts/migrations/0010_auto_20151111_2239.py
+++ b/tracpro/contacts/migrations/0010_auto_20151111_2239.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0009_show_facility_code_field'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='datafield',
+            name='key',
+            field=models.CharField(max_length=255, verbose_name='key'),
+        ),
+        migrations.AlterField(
+            model_name='datafield',
+            name='label',
+            field=models.CharField(max_length=255, verbose_name='label', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='datafield',
+            name='org',
+            field=models.ForeignKey(verbose_name='org', to='orgs.Org'),
+        ),
+        migrations.AlterField(
+            model_name='datafield',
+            name='show_on_tracpro',
+            field=models.BooleanField(default=False, verbose_name='show_on_tracpro'),
+        ),
+        migrations.AlterField(
+            model_name='datafield',
+            name='value_type',
+            field=models.CharField(max_length=1, verbose_name='value type', choices=[('T', 'Text'), ('N', 'Numeric'), ('D', 'Datetime'), ('S', 'State'), ('I', 'District')]),
+        ),
+    ]

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -265,11 +265,16 @@ class DataField(models.Model):
         (TYPE_DISTRICT, _("District")),
     )
 
-    org = models.ForeignKey("orgs.Org")
-    label = models.CharField(max_length=255, blank=True)
-    key = models.CharField(max_length=255)
-    value_type = models.CharField(max_length=1, choices=TYPE_CHOICES)
-    show_on_tracpro = models.BooleanField(default=False)
+    org = models.ForeignKey(
+        "orgs.Org", verbose_name=_("org"))
+    label = models.CharField(
+        max_length=255, blank=True, verbose_name=_("label"))
+    key = models.CharField(
+        max_length=255, verbose_name=_("key"))
+    value_type = models.CharField(
+        max_length=1, choices=TYPE_CHOICES, verbose_name=_("value type"))
+    show_on_tracpro = models.BooleanField(
+        default=False, verbose_name=_("show_on_tracpro"))
 
     objects = DataFieldManager()
 

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -220,12 +220,6 @@ class DataFieldQuerySet(models.QuerySet):
     def by_org(self, org):
         return self.filter(org=org)
 
-    def show_on_tracpro(self):
-        return self.update(show_on_tracpro=True)
-
-    def hide_on_tracpro(self):
-        return self.update(show_on_tracpro=False)
-
 
 class DataFieldManager(models.Manager.from_queryset(DataFieldQuerySet)):
 
@@ -249,8 +243,8 @@ class DataFieldManager(models.Manager.from_queryset(DataFieldQuerySet)):
 
     def set_active_for_org(self, org, keys):
         fields = DataField.objects.by_org(org)
-        fields.filter(key__in=keys).show_on_tracpro()
-        fields.exclude(key__in=keys).hide_on_tracpro()
+        fields.filter(key__in=keys).update(show_on_tracpro=True)
+        fields.exclude(key__in=keys).update(show_on_tracpro=False)
 
 
 class DataField(models.Model):

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -239,8 +239,6 @@ class DataFieldManager(models.Manager.from_queryset(DataFieldQuerySet)):
             field.value_type = temba_field.value_type
             field.save()
 
-        return temba_fields.keys()
-
     def set_active_for_org(self, org, keys):
         fields = DataField.objects.by_org(org)
         fields.filter(key__in=keys).update(show_on_tracpro=True)

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -272,7 +272,7 @@ class DataField(models.Model):
     value_type = models.CharField(
         max_length=1, choices=TYPE_CHOICES, verbose_name=_("value type"))
     show_on_tracpro = models.BooleanField(
-        default=False, verbose_name=_("show_on_tracpro"))
+        default=False, verbose_name=_("show on TracPro"))
 
     objects = DataFieldManager()
 

--- a/tracpro/contacts/tasks.py
+++ b/tracpro/contacts/tasks.py
@@ -84,16 +84,16 @@ def sync_all_contacts():
 
 
 @task
-def sync_all_fields():
+def sync_all_data_fields():
     """Remove any contact fields that have been removed remotely."""
     logger.info("Syncing DataFields for active orgs.")
     for org in Org.objects.filter(is_active=True):
-        run_org_task(org, sync_org_fields)
+        run_org_task(org, sync_org_data_fields)
     logger.info("Finished syncing DataFields for active orgs.")
 
 
 @task
-def sync_org_fields(org_pk):
+def sync_org_data_fields(org_pk):
     """Sync an org's DataFields.
 
     Syncs DataField info and removes any DataFields (and associated contact

--- a/tracpro/groups/views.py
+++ b/tracpro/groups/views.py
@@ -124,7 +124,7 @@ class RegionCRUDL(SmartCRUDL):
             regions = regions.prefetch_related(
                 Prefetch(
                     "contacts",
-                    Contact.objects.filter(is_active=True),
+                    Contact.objects.active(),
                     "prefetched_contacts",
                 ),
             )

--- a/tracpro/home/views.py
+++ b/tracpro/home/views.py
@@ -22,7 +22,7 @@ class HomeView(OrgPermsMixin, SmartTemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(HomeView, self).get_context_data(**kwargs)
-        context['polls'] = Poll.get_all(self.request.org).order_by('name')
+        context['polls'] = Poll.objects.active().by_org(self.request.org).order_by('name')
         # Loop through all baseline terms, until we find one with data
         baselineterms = BaselineTerm.get_all(self.request.org).order_by('-end_date')
         for baselineterm in baselineterms:

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -86,6 +86,8 @@ class OrgExtForm(OrgForm):
 
         if 'contact_fields' in self.fields:
             # Set hook that will be picked up by a post-save signal.
+            # Must be done post-save to avoid making changes if any earlier
+            # part of the transaction fails.
             self.instance._visible_data_fields = self.cleaned_data.get('contact_fields')
 
         return super(OrgExtForm, self).save(*args, **kwargs)

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -25,8 +25,8 @@ class OrgExtForm(OrgForm):
     show_spoof_data = forms.BooleanField(
         required=False,
         help_text=_("Whether to show spoof data for this organization."))
-    contact_fields = forms.MultipleChoiceField(
-        choices=[], required=False,
+    contact_fields = forms.ModelMultipleChoiceField(
+        queryset=None, required=False,
         help_text=_("Custom contact data fields that should be visible "
                     "and editable in TracPro."))
 
@@ -60,11 +60,9 @@ class OrgExtForm(OrgForm):
                 else:
                     raise
 
-            queryset = self.instance.datafield_set.all()
-            choices = [(f.key, f.display_name) for f in queryset]
-            initial = list(queryset.visible().values_list('key', flat=True))
-            self.fields['contact_fields'].choices = choices
-            self.fields['contact_fields'].initial = initial
+            data_fields = self.instance.datafield_set.all()
+            self.fields['contact_fields'].queryset = data_fields
+            self.fields['contact_fields'].initial = data_fields.visible()
 
     def clean(self):
         """Ensure the default language is chosen from the available languages."""

--- a/tracpro/orgs_ext/signals.py
+++ b/tracpro/orgs_ext/signals.py
@@ -10,4 +10,5 @@ from tracpro.contacts.models import DataField
 def set_visible_data_fields(sender, instance, **kwargs):
     """Hook to update the visible DataFields for an org."""
     if hasattr(instance, '_visible_data_fields'):
-        DataField.objects.set_active_for_org(instance, instance._visible_data_fields)
+        keys = instance._visible_data_fields.values_list('key', flat=True)
+        DataField.objects.set_active_for_org(instance, keys)

--- a/tracpro/polls/__init__.py
+++ b/tracpro/polls/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'rowan'

--- a/tracpro/polls/charts.py
+++ b/tracpro/polls/charts.py
@@ -33,15 +33,15 @@ def single_pollrun(pollrun, question, regions):
     Will be a word cloud for open-ended questions, and pie chart of categories
     for everything else.
     """
-    if question.type == Question.TYPE_OPEN:
+    if question.question_type == Question.TYPE_OPEN:
         word_counts = pollrun.get_answer_word_counts(question, regions)
         chart_type = 'word'
         chart_data = word_cloud_data(word_counts)
-    elif question.type in (Question.TYPE_MULTIPLE_CHOICE, Question.TYPE_KEYPAD, Question.TYPE_MENU):
+    elif question.question_type in (Question.TYPE_MULTIPLE_CHOICE, Question.TYPE_KEYPAD, Question.TYPE_MENU):
         category_counts = pollrun.get_answer_category_counts(question, regions)
         chart_type = 'pie'
         chart_data = pie_chart_data(category_counts)
-    elif question.type == Question.TYPE_NUMERIC:
+    elif question.question_type == Question.TYPE_NUMERIC:
         range_counts = pollrun.get_answer_auto_range_counts(question, regions)
         chart_type = 'column'
         chart_data = column_chart_data(range_counts)
@@ -55,7 +55,7 @@ def single_pollrun(pollrun, question, regions):
 def multiple_pollruns_old(pollruns, question, regions):
     """Chart data for multiple pollruns of a poll."""
 
-    if question.type == Question.TYPE_OPEN:
+    if question.question_type == Question.TYPE_OPEN:
         overall_counts = defaultdict(int)
 
         for pollrun in pollruns:
@@ -67,7 +67,7 @@ def multiple_pollruns_old(pollruns, question, regions):
             overall_counts.items(), key=itemgetter(1), reverse=True)
         chart_type = 'word'
         chart_data = word_cloud_data(sorted_counts[:50])
-    elif question.type == Question.TYPE_MULTIPLE_CHOICE:
+    elif question.question_type == Question.TYPE_MULTIPLE_CHOICE:
         categories = set()
         counts_by_pollrun = OrderedDict()
 
@@ -92,7 +92,7 @@ def multiple_pollruns_old(pollruns, question, regions):
         chart_type = 'time-area'
         chart_data = [{'name': cgi.escape(category), 'data': data}
                       for category, data in category_series.iteritems()]
-    elif question.type == Question.TYPE_NUMERIC:
+    elif question.question_type == Question.TYPE_NUMERIC:
         chart_type = 'time-line'
         chart_data = []
         for pollrun in pollruns:

--- a/tracpro/polls/forms.py
+++ b/tracpro/polls/forms.py
@@ -5,19 +5,24 @@ from . import models
 
 
 class PollForm(forms.ModelForm):
-    name = forms.CharField(label=_("Name"))
 
     class Meta:
         model = models.Poll
-        fields = forms.ALL_FIELDS
+        fields = ('name',)
 
-    def __init__(self, *args, **kwargs):
-        super(PollForm, self).__init__(*args, **kwargs)
-        for question in self.instance.get_questions():
-            field_key = '__question__%d__text' % question.pk
-            self.fields[field_key] = forms.CharField(
-                max_length=255, initial=question.display_name,
-                label=_("Question #%d") % question.order)
+
+class QuestionForm(forms.ModelForm):
+
+    class Meta:
+        model = models.Question
+        fields = ('name', 'question_type', 'is_active')
+
+
+QuestionFormSet = forms.modelformset_factory(
+    models.Question,
+    form=QuestionForm,
+    extra=0,
+    can_delete=False)
 
 
 class ActivePollsForm(forms.Form):

--- a/tracpro/polls/forms.py
+++ b/tracpro/polls/forms.py
@@ -16,7 +16,7 @@ class PollForm(forms.ModelForm):
         for question in self.instance.get_questions():
             field_key = '__question__%d__text' % question.pk
             self.fields[field_key] = forms.CharField(
-                max_length=255, initial=question.text,
+                max_length=255, initial=question.display_name,
                 label=_("Question #%d") % question.order)
 
 

--- a/tracpro/polls/forms.py
+++ b/tracpro/polls/forms.py
@@ -1,14 +1,14 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
-from .models import Poll
+from . import models
 
 
 class PollForm(forms.ModelForm):
     name = forms.CharField(label=_("Name"))
 
     class Meta:
-        model = Poll
+        model = models.Poll
         fields = forms.ALL_FIELDS
 
     def __init__(self, *args, **kwargs):
@@ -20,17 +20,24 @@ class PollForm(forms.ModelForm):
                 label=_("Question #%d") % question.order)
 
 
-class FlowsForm(forms.Form):
-    flows = forms.MultipleChoiceField(
-        choices=(), label=_("Flows"),
+class ActivePollsForm(forms.Form):
+    """Set which polls should be synced with RapidPro."""
+    polls = forms.ModelMultipleChoiceField(
+        queryset=None, required=False, label=_("Active flows"),
         help_text=_("Flows to track as polls."))
 
-    def __init__(self, *args, **kwargs):
-        org = kwargs.pop('org')
-        super(FlowsForm, self).__init__(*args, **kwargs)
-        choices = []
-        for flow in org.get_temba_client().get_flows(archived=False):
-            choices.append((flow.uuid, flow.name))
+    def __init__(self, org, *args, **kwargs):
+        self.org = org
+        super(ActivePollsForm, self).__init__(*args, **kwargs)
 
-        self.fields['flows'].choices = choices
-        self.fields['flows'].initial = [p.flow_uuid for p in Poll.get_all(org)]
+        # Make sure we have the most up-to-date Poll info.
+        # NOTE: This makes an in-band request to an external API.
+        models.Poll.objects.sync(self.org)
+
+        polls = models.Poll.objects.by_org(self.org)
+        self.fields['polls'].queryset = polls
+        self.fields['polls'].initial = polls.active()
+
+    def save(self):
+        uuids = self.cleaned_data['polls'].values_list('flow_uuid', flat=True)
+        models.Poll.objects.set_active_for_org(self.org, uuids)

--- a/tracpro/polls/management/commands/fetchruns.py
+++ b/tracpro/polls/management/commands/fetchruns.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
 
         client = org.get_temba_client()
 
-        polls_by_flow_uuids = {p.flow_uuid: p for p in Poll.get_all(org)}
+        polls_by_flow_uuids = {p.flow_uuid: p for p in Poll.objects.active().by_org(org)}
 
         runs = client.get_runs(flows=polls_by_flow_uuids.keys(), after=since)
 

--- a/tracpro/polls/migrations/0027_rename_question_text_to_name.py
+++ b/tracpro/polls/migrations/0027_rename_question_text_to_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('polls', '0026_auto_20150930_1334'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='question',
+            old_name='text',
+            new_name='name',
+        )
+    ]

--- a/tracpro/polls/migrations/0028_question_tweaks.py
+++ b/tracpro/polls/migrations/0028_question_tweaks.py
@@ -20,26 +20,36 @@ class Migration(migrations.Migration):
             old_name='type',
             new_name='question_type',
         ),
+        migrations.AlterField(
+            model_name='question',
+            name='question_type',
+            field=models.CharField(max_length=1, verbose_name='question type', choices=[('O', 'Open Ended'), ('C', 'Multiple Choice'), ('N', 'Numeric'), ('M', 'Menu'), ('K', 'Keypad'), ('R', 'Recording')]),
+        ),
         migrations.AddField(
             model_name='question',
             name='rapidpro_name',
-            field=models.CharField(default='', max_length=64),
+            field=models.CharField(default='', max_length=64, verbose_name='RapidPro name'),
             preserve_default=False,
         ),
         migrations.AlterField(
             model_name='question',
+            name='poll',
+            field=models.ForeignKey(related_name='questions', verbose_name='poll', to='polls.Poll'),
+        ),
+        migrations.AlterField(
+            model_name='question',
             name='is_active',
-            field=models.BooleanField(default=True, verbose_name='Show on TracPro'),
+            field=models.BooleanField(default=True, verbose_name='show on TracPro'),
         ),
         migrations.AlterField(
             model_name='question',
             name='name',
-            field=models.CharField(max_length=64, blank=True),
+            field=models.CharField(max_length=64, verbose_name='name', blank=True),
         ),
         migrations.AlterField(
             model_name='question',
             name='order',
-            field=models.IntegerField(default=0),
+            field=models.IntegerField(default=0, verbose_name='order'),
         ),
         migrations.AlterField(
             model_name='question',

--- a/tracpro/polls/migrations/0028_question_tweaks.py
+++ b/tracpro/polls/migrations/0028_question_tweaks.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('polls', '0027_rename_question_text_to_name'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='question',
+            options={'ordering': ('order',)},
+        ),
+        migrations.RenameField(
+            model_name='question',
+            old_name='type',
+            new_name='question_type',
+        ),
+        migrations.AddField(
+            model_name='question',
+            name='rapidpro_name',
+            field=models.CharField(default='', max_length=64),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='question',
+            name='is_active',
+            field=models.BooleanField(default=True, verbose_name='Show on TracPro'),
+        ),
+        migrations.AlterField(
+            model_name='question',
+            name='name',
+            field=models.CharField(max_length=64, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='question',
+            name='order',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='question',
+            name='ruleset_uuid',
+            field=models.CharField(max_length=36),
+        ),
+        migrations.AlterUniqueTogether(
+            name='question',
+            unique_together=set([('ruleset_uuid', 'poll')]),
+        ),
+    ]

--- a/tracpro/polls/migrations/0029_poll_tweaks.py
+++ b/tracpro/polls/migrations/0029_poll_tweaks.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='poll',
             name='rapidpro_name',
-            field=models.CharField(default='', max_length=64),
+            field=models.CharField(default='', max_length=64, verbose_name='RapidPro name'),
             preserve_default=False,
         ),
         migrations.AlterField(
@@ -25,17 +25,17 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='poll',
             name='is_active',
-            field=models.BooleanField(default=False, verbose_name='Show on TracPro'),
+            field=models.BooleanField(default=False, verbose_name='show on TracPro'),
         ),
         migrations.AlterField(
             model_name='poll',
             name='name',
-            field=models.CharField(max_length=64, blank=True),
+            field=models.CharField(max_length=64, blank=True, verbose_name='name'),
         ),
         migrations.AlterField(
             model_name='poll',
             name='org',
-            field=models.ForeignKey(related_name='polls', to='orgs.Org'),
+            field=models.ForeignKey(related_name='polls', verbose_name='org', to='orgs.Org'),
         ),
         migrations.AlterUniqueTogether(
             name='poll',

--- a/tracpro/polls/migrations/0029_poll_tweaks.py
+++ b/tracpro/polls/migrations/0029_poll_tweaks.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('polls', '0028_question_tweaks'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='poll',
+            name='rapidpro_name',
+            field=models.CharField(default='', max_length=64),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='poll',
+            name='flow_uuid',
+            field=models.CharField(max_length=36),
+        ),
+        migrations.AlterField(
+            model_name='poll',
+            name='is_active',
+            field=models.BooleanField(default=False, verbose_name='Show on TracPro'),
+        ),
+        migrations.AlterField(
+            model_name='poll',
+            name='name',
+            field=models.CharField(max_length=64, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='poll',
+            name='org',
+            field=models.ForeignKey(related_name='polls', to='orgs.Org'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='poll',
+            unique_together=set([('org', 'flow_uuid')]),
+        ),
+    ]

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -121,14 +121,18 @@ class Poll(models.Model):
     as Polls.
     """
     flow_uuid = models.CharField(max_length=36)
-    org = models.ForeignKey('orgs.Org', related_name='polls')
-    rapidpro_name = models.CharField(max_length=64)
-    name = models.CharField(max_length=64, blank=True)
+    org = models.ForeignKey(
+        'orgs.Org', related_name='polls', verbose_name=_('org'))
+    rapidpro_name = models.CharField(
+        max_length=64, verbose_name=_('RapidPro name'))
+    name = models.CharField(
+        max_length=64, blank=True, verbose_name=_('name'))
 
     # Set this to False rather than deleting a Poll. If the user should
     # re-select the corresponding flow later, we can avoid re-importing
     # existing data.
-    is_active = models.BooleanField(default=False, verbose_name=_("Show on TracPro"))
+    is_active = models.BooleanField(
+        default=False, verbose_name=_("show on TracPro"))
 
     objects = PollManager()
 
@@ -204,13 +208,18 @@ class Question(models.Model):
     )
 
     ruleset_uuid = models.CharField(max_length=36)
-    poll = models.ForeignKey('polls.Poll', related_name='questions')
-    rapidpro_name = models.CharField(max_length=64)
-    name = models.CharField(max_length=64, blank=True)
-    question_type = models.CharField(max_length=1, choices=TYPE_CHOICES)
-    order = models.IntegerField(default=0)
-
-    is_active = models.BooleanField(default=True, verbose_name=_("Show on TracPro"))
+    poll = models.ForeignKey(
+        'polls.Poll', related_name='questions', verbose_name=_('poll'))
+    rapidpro_name = models.CharField(
+        max_length=64, verbose_name=_('RapidPro name'))
+    name = models.CharField(
+        max_length=64, blank=True, verbose_name=_('name'))
+    question_type = models.CharField(
+        max_length=1, choices=TYPE_CHOICES, verbose_name=_('question type'))
+    order = models.IntegerField(
+        default=0, verbose_name=_('order'))
+    is_active = models.BooleanField(
+        default=True, verbose_name=_("show on TracPro"))
 
     objects = QuestionManager()
 

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -150,7 +150,7 @@ class Poll(models.Model):
 
         This allows us to track changes to the name on RapidPro.
         """
-        self.name = self.name if self.name != self.rapidpro_name else ""
+        self.name = "" if self.name == self.rapidpro_name else self.name.strip()
         super(Poll, self).save(*args, **kwargs)
         self.name = self.name or self.rapidpro_name
 
@@ -233,7 +233,7 @@ class Question(models.Model):
 
         This allows us to track changes to the name on RapidPro.
         """
-        self.name = self.name if self.name != self.rapidpro_name else ""
+        self.name = "" if self.name == self.rapidpro_name else self.name.strip()
         super(Question, self).save(*args, **kwargs)
         self.name = self.name or self.rapidpro_name
 

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -154,9 +154,6 @@ class Poll(models.Model):
         super(Poll, self).save(*args, **kwargs)
         self.name = self.name or self.rapidpro_name
 
-    def get_pollruns(self, org, region=None, include_subregions=True):
-        return PollRun.objects.get_all(org, region, include_subregions).filter(poll=self)
-
 
 class QuestionQuerySet(models.QuerySet):
 

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -154,10 +154,6 @@ class Poll(models.Model):
         super(Poll, self).save(*args, **kwargs)
         self.name = self.name or self.rapidpro_name
 
-    @classmethod
-    def get_all(cls, org):
-        return Poll.objects.active().by_org(org)
-
     def get_pollruns(self, org, region=None, include_subregions=True):
         return PollRun.objects.get_all(org, region, include_subregions).filter(poll=self)
 
@@ -599,7 +595,7 @@ class Response(models.Model):
             return response
 
         if not poll:
-            poll = Poll.get_all(org).get(flow_uuid=run.flow)
+            poll = Poll.objects.active().by_org(org).get(flow_uuid=run.flow)
 
         contact = Contact.get_or_fetch(poll.org, uuid=run.contact)
 

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -65,7 +65,7 @@ def fetch_org_runs(org_id):
     until = timezone.now()
 
     total_runs = 0
-    for poll in Poll.get_all(org):
+    for poll in Poll.objects.active().by_org(org):
         poll_runs = client.get_runs(flows=[poll.flow_uuid], after=last_time, before=until)
         total_runs += len(poll_runs)
 

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -100,7 +100,7 @@ def pollrun_start(pollrun_id):
     org = pollrun.poll.org
     client = org.get_temba_client()
 
-    contacts = Contact.objects.filter(is_active=True)
+    contacts = Contact.objects.active()
     if pollrun.pollrun_type == PollRun.TYPE_PROPAGATED:
         descendants = pollrun.region.get_descendants(include_self=True)
         contacts = contacts.filter(region__in=descendants)

--- a/tracpro/polls/tests/factories.py
+++ b/tracpro/polls/tests/factories.py
@@ -75,8 +75,9 @@ class PropagatedPollRun(PollRun):
 class Question(factory.django.DjangoModelFactory):
     ruleset_uuid = FuzzyUUID()
     poll = factory.SubFactory('tracpro.test.factories.Poll')
-    text = factory.fuzzy.FuzzyText()
-    type = factory.fuzzy.FuzzyChoice(c[0] for c in models.Question.TYPE_CHOICES)
+    rapidpro_name = factory.LazyAttribute(lambda o: o.name)
+    name = factory.fuzzy.FuzzyText()
+    question_type = factory.fuzzy.FuzzyChoice(c[0] for c in models.Question.TYPE_CHOICES)
     order = factory.Sequence(lambda n: n)
 
     class Meta:

--- a/tracpro/polls/tests/factories.py
+++ b/tracpro/polls/tests/factories.py
@@ -18,7 +18,9 @@ __all__ = [
 class Poll(factory.django.DjangoModelFactory):
     flow_uuid = FuzzyUUID()
     org = factory.SubFactory("tracpro.test.factories.Org")
+    rapidpro_name = factory.LazyAttribute(lambda o: o.name)
     name = factory.fuzzy.FuzzyText()
+    is_active = True
 
     class Meta:
         model = models.Poll

--- a/tracpro/polls/tests/test_models.py
+++ b/tracpro/polls/tests/test_models.py
@@ -59,14 +59,6 @@ class PollTest(TracProDataTest):
         # existing poll that was inactive should now be active
         self.assertTrue(Poll.objects.get(flow_uuid='F-001').is_active)
 
-    def test_get_questions(self):
-        self.assertEqual(
-            list(self.poll1.get_questions()),
-            [self.poll1_question1, self.poll1_question2])
-        self.assertEqual(
-            list(self.poll2.get_questions()),
-            [self.poll2_question1])
-
 
 class PollRunTest(TracProDataTest):
 

--- a/tracpro/polls/tests/test_models.py
+++ b/tracpro/polls/tests/test_models.py
@@ -7,57 +7,312 @@ from mock import patch
 
 import pytz
 
-from temba_client.types import Flow, RuleSet, Run, RunValueSet
+from temba_client.types import Run, RunValueSet
 
+from django.db import IntegrityError
 from django.utils import timezone
 
-from tracpro.test.cases import TracProDataTest
+from tracpro.test import factories
+from tracpro.test.cases import TracProTest, TracProDataTest
 
 from ..models import Answer, Poll, PollRun, Response
-from . import factories
+from .. import models
 
 
-class PollTest(TracProDataTest):
+class TestPollQuerySet(TracProTest):
+
+    def test_active(self):
+        """active filter shouldn't return Polls where is_active is False."""
+        poll = factories.Poll(is_active=True)
+        factories.Poll(is_active=False)
+        self.assertEqual(list(models.Poll.objects.active()), [poll])
+
+    def test_by_org(self):
+        """by_org filter should return only Polls for the given org."""
+        org = factories.Org()
+        poll = factories.Poll(org=org)
+        factories.Poll()
+        self.assertEqual(list(models.Poll.objects.by_org(org)), [poll])
+
+
+class TestPollManager(TracProTest):
+
+    def test_set_active_for_org(self):
+        """Set which org polls are active."""
+        polls = []
+
+        org = factories.Org()
+        polls.append(factories.Poll(org=org, is_active=True, flow_uuid='0'))
+        polls.append(factories.Poll(org=org, is_active=True, flow_uuid='1'))
+        polls.append(factories.Poll(org=org, is_active=False, flow_uuid='2'))
+        polls.append(factories.Poll(org=org, is_active=False, flow_uuid='3'))
+
+        other_org = factories.Org()
+        polls.append(factories.Poll(org=other_org, is_active=True, flow_uuid='4'))
+        polls.append(factories.Poll(org=other_org, is_active=False, flow_uuid='5'))
+
+        models.Poll.objects.set_active_for_org(org, ['0', '2'])
+
+        # Refresh from database.
+        polls = [models.Poll.objects.get(pk=p.pk) for p in polls]
+
+        # Specified org Polls should be active.
+        self.assertTrue(polls[0].is_active)
+        self.assertTrue(polls[2].is_active)
+
+        # All other org polls should be inactive.
+        self.assertFalse(polls[1].is_active)
+        self.assertFalse(polls[3].is_active)
+
+        # Polls for other orgs should be unaffected.
+        self.assertTrue(polls[4].is_active)
+        self.assertFalse(polls[5].is_active)
+
+    def test_set_active_for_org__invalid_uuids(self):
+        """An error is raised when an invalid UUID for the org is passed."""
+        org = factories.Org()
+        factories.Poll(org=org, is_active=False, flow_uuid='a')
+
+        other_org = factories.Org()
+        factories.Poll(org=other_org, is_active=False, flow_uuid='b')
+
+        with self.assertRaises(ValueError):
+            Poll.objects.set_active_for_org(org, ['a', 'b'])
+
+    def test_from_temba__existing(self):
+        """Fields on an existing Poll should be updated from RapidPro."""
+        org = factories.Org()
+        poll = factories.Poll(
+            org=org, flow_uuid='abc', rapidpro_name='old', name='custom',
+            is_active=True)
+        flow = factories.TembaFlow(uuid='abc', name='new')
+
+        updated = Poll.objects.from_temba(org, flow)
+
+        poll.refresh_from_db()
+        self.assertEqual(poll.pk, updated.pk)
+        self.assertEqual(poll.rapidpro_name, 'new')
+        self.assertEqual(poll.name, 'custom')
+        self.assertTrue(poll.is_active)
+
+    def test_from_temba__new_active(self):
+        """A new inactive Poll should be created to match RapidPro data."""
+        org = factories.Org()
+        flow = factories.TembaFlow()
+
+        poll = Poll.objects.from_temba(org, flow)
+
+        self.assertEqual(poll.flow_uuid, flow.uuid)
+        self.assertEqual(poll.rapidpro_name, flow.name)
+        self.assertEqual(poll.name, flow.name)
+        self.assertFalse(poll.is_active)
+
+    def test_from_temba__existing_archived(self):
+        """Existing Poll should be deactivated if RapidPro flow is archived."""
+        org = factories.Org()
+        poll = factories.Poll(org=org, flow_uuid='abc', is_active=True)
+        flow = factories.TembaFlow(uuid='abc', archived=True)
+
+        poll = Poll.objects.from_temba(org, flow)
+
+        self.assertFalse(poll.is_active)
+
+    def test_from_temba__new_archive(self):
+        """New Poll should be created as inactive if RapidPro flow is archived."""
+        org = factories.Org()
+        flow = factories.TembaFlow(archived=True)
+
+        poll = Poll.objects.from_temba(org, flow)
+
+        self.assertFalse(poll.is_active)
 
     @patch('dash.orgs.models.TembaClient.get_flows')
-    def test_sync_with_flows(self, mock_get_flows):
-        mock_get_flows.return_value = [
-            Flow.create(name="Poll #3", uuid='F-003', rulesets=[
-                RuleSet.create(uuid='RS-004', label='How old are you', response_type='C'),
-                RuleSet.create(uuid='RS-005', label='Where do you live', response_type='O')
-            ]),
-            Flow.create(name="Poll #4", uuid='F-004', rulesets=[
-                RuleSet.create(uuid='RS-006', label='How many goats', response_type='N'),
-                RuleSet.create(uuid='RS-007', label='How many sheep', response_type='N')
-            ]),
-            Flow.create(name="Poll #5", uuid='F-005', rulesets=[
-                RuleSet.create(uuid='RS-008', label='What time is it', response_type='O')
-            ])
-        ]
-        Poll.sync_with_flows(self.unicef, ['F-003', 'F-004'])
+    def test_sync__delete_non_existant_poll(self, mock_get_flows):
+        """Sync should delete Polls that track a flow that does not exist."""
+        org = factories.Org()
+        poll = factories.Poll(org=org)  # noqa
+        mock_get_flows.return_value = []
+        models.Poll.objects.sync(org)
 
-        self.assertEqual(self.unicef.polls.filter(is_active=True).count(), 2)
+        self.assertEqual(models.Poll.objects.count(), 0)
 
-        # existing poll that wasn't included should now be inactive
-        self.assertFalse(Poll.objects.get(flow_uuid='F-001').is_active)
+    @patch('dash.orgs.models.TembaClient.get_flows')
+    def test_sync__delete_non_existant_question(self, mock_get_flows):
+        org = factories.Org()
+        poll = factories.Poll(org=org)
+        question = factories.Question(poll=poll)  # noqa
+        flow = factories.TembaFlow(uuid=poll.flow_uuid)  # no questions
+        mock_get_flows.return_value = [flow]
+        models.Poll.objects.sync(org)
 
-        poll3 = Poll.objects.get(flow_uuid='F-003')
-        self.assertEqual(poll3.name, "Poll #3")
-        self.assertEqual(poll3.questions.count(), 2)
-        self.assertEqual(str(poll3), "Poll #3")
+        self.assertEqual(models.Poll.objects.count(), 1)
+        self.assertEqual(models.Question.objects.count(), 0)
 
-        # switch back to flow #1
-        mock_get_flows.return_value = [
-            Flow.create(name="Poll #1", uuid='F-001', rulesets=[
-                RuleSet.create(uuid='RS-001', label='Number of sheep', response_type='N'),
-                RuleSet.create(uuid='RS-002', label='Number of goats', response_type='N')
-            ])
-        ]
+    @patch('dash.orgs.models.TembaClient.get_flows')
+    def test_sync__add_new(self, mock_get_flows):
+        """Sync should create an inactive poll to track a new flow."""
+        org = factories.Org()
+        flow = factories.TembaFlow()
+        ruleset = factories.TembaRuleSet()
+        flow.rulesets = [ruleset]
+        mock_get_flows.return_value = [flow]
+        models.Poll.objects.sync(org)
 
-        Poll.sync_with_flows(self.unicef, ['F-001'])
+        self.assertEqual(models.Poll.objects.count(), 1)
+        poll = models.Poll.objects.get()
+        self.assertFalse(poll.is_active)
+        self.assertEqual(poll.rapidpro_name, flow.name)
+        self.assertEqual(poll.name, flow.name)
 
-        # existing poll that was inactive should now be active
-        self.assertTrue(Poll.objects.get(flow_uuid='F-001').is_active)
+        self.assertEqual(models.Question.objects.count(), 1)
+        question = models.Question.objects.get()
+        self.assertEqual(question.poll, poll)
+        self.assertEqual(question.ruleset_uuid, ruleset.uuid)
+        self.assertEqual(question.rapidpro_name, ruleset.label)
+        self.assertEqual(question.name, ruleset.label)
+        self.assertEqual(question.order, 1)
+
+    @patch('dash.orgs.models.TembaClient.get_flows')
+    def test_sync__update_existing(self, mock_get_flows):
+        """Sync should update existing objects if they have changed on RapidPro."""
+        org = factories.Org()
+        poll = factories.Poll(org=org, is_active=True)
+        question = factories.Question(poll=poll)
+        flow = factories.TembaFlow(uuid=poll.flow_uuid)
+        ruleset = factories.TembaRuleSet(uuid=question.ruleset_uuid)
+        flow.rulesets = [ruleset]
+        mock_get_flows.return_value = [flow]
+        models.Poll.objects.sync(org)
+
+        self.assertEqual(models.Poll.objects.count(), 1)
+        poll = models.Poll.objects.get()
+        self.assertEqual(poll.org, org)
+        self.assertEqual(poll.flow_uuid, flow.uuid)
+        self.assertEqual(poll.rapidpro_name, flow.name)
+        self.assertEqual(poll.name, flow.name)
+        self.assertTrue(poll.is_active)
+
+        self.assertEqual(models.Question.objects.count(), 1)
+        question = models.Question.objects.get()
+        self.assertEqual(question.poll, poll)
+        self.assertEqual(question.ruleset_uuid, ruleset.uuid)
+        self.assertEqual(question.rapidpro_name, ruleset.label)
+        self.assertEqual(question.name, ruleset.label)
+        self.assertEqual(question.order, 1)
+
+    @patch('dash.orgs.models.TembaClient.get_flows')
+    def test_sync__archive_poll(self, mock_get_flows):
+        """Sync should deactivate the Poll if it is archived on RapidPro."""
+        org = factories.Org()
+        poll = factories.Poll(org=org, is_active=True)
+        flow = factories.TembaFlow(uuid=poll.flow_uuid, archived=True)
+        mock_get_flows.return_value = [flow]
+        models.Poll.objects.sync(org)
+
+        self.assertEqual(models.Poll.objects.count(), 1)
+        poll = models.Poll.objects.get()
+        self.assertEqual(poll.org, org)
+        self.assertEqual(poll.flow_uuid, flow.uuid)
+        self.assertFalse(poll.is_active)
+
+
+class TestPoll(TracProTest):
+
+    def test_str(self):
+        """Smoke test for string representation."""
+        poll = factories.Poll(name='hello')
+        self.assertEqual(str(poll), 'hello')
+
+    def test_flow_uuid_unique_to_org(self):
+        """flow_uuid should be unique for a given Org."""
+        org = factories.Org()
+        factories.Poll(org=org, flow_uuid='abc')
+        with self.assertRaises(IntegrityError):
+            factories.Poll(org=org, flow_uuid='abc')
+
+    def test_flow_uuid_can_repeat_between_orgs(self):
+        """flow_uuid can be repeated with different Orgs."""
+        factories.Poll(org=factories.Org(), flow_uuid='abc')
+        factories.Poll(org=factories.Org(), flow_uuid='abc')
+
+
+class TestQuestionQueryset(TracProTest):
+
+    def test_active(self):
+        """is_active() queryset filter should not return Questions with is_active=False."""
+        question = factories.Question(is_active=True)
+        factories.Question(is_active=False)
+        self.assertEqual(list(models.Question.objects.active()), [question])
+
+
+class TestQuestionManager(TracProTest):
+
+    def test_from_temba__new(self):
+        """Should create a new Question to match the Poll and uuid."""
+        poll = factories.Poll()
+        ruleset = factories.TembaRuleSet()
+
+        # Should create a new Question object that matches the incoming data.
+        question = models.Question.objects.from_temba(poll, ruleset, order=100)
+        self.assertEqual(question.ruleset_uuid, ruleset.uuid)
+        self.assertEqual(question.poll, poll)
+        self.assertEqual(question.rapidpro_name, ruleset.label)
+        self.assertEqual(question.question_type, ruleset.response_type)
+        self.assertEqual(question.order, 100)
+
+    def test_from_temba__existing(self):
+        """Should update an existing Question for the Poll and uuid."""
+        poll = factories.Poll()
+        question = factories.Question(poll=poll)
+        ruleset = factories.TembaRuleSet(uuid=question.ruleset_uuid)
+
+        # Should return the existing Question object.
+        ret_val = models.Question.objects.from_temba(poll, ruleset, order=100)
+        self.assertEqual(ret_val, question)
+        self.assertEqual(ret_val.ruleset_uuid, question.ruleset_uuid)
+
+        # Existing Question should be updated to match the incoming data.
+        question.refresh_from_db()
+        self.assertEqual(question.ruleset_uuid, ruleset.uuid)
+        self.assertEqual(question.poll, poll)
+        self.assertEqual(question.rapidpro_name, ruleset.label)
+        self.assertEqual(question.question_type, ruleset.response_type)
+        self.assertEqual(question.order, 100)
+
+    def test_from_temba__another_org(self):
+        """Both uuid and Poll must match in order to update existing."""
+        poll = factories.Poll()
+        other_poll = factories.Poll()
+        other_question = factories.Question(poll=other_poll)
+        ruleset = factories.TembaRuleSet(uuid=other_question.ruleset_uuid)
+
+        # Should return a Question that is distinct from the existing
+        # Question for another poll.
+        ret_val = models.Question.objects.from_temba(poll, ruleset, order=100)
+        other_question.refresh_from_db()
+        self.assertNotEqual(ret_val, other_question)
+        self.assertNotEqual(ret_val.poll, other_question.poll)
+        self.assertEqual(ret_val.ruleset_uuid, other_question.ruleset_uuid)
+
+
+class TestQuestion(TracProTest):
+
+    def test_str(self):
+        """Smoke test for string representation."""
+        question = factories.Question(name='hello')
+        self.assertEqual(str(question), 'hello')
+
+    def test_ruleset_uuid_unique_to_poll(self):
+        """ruleset_uuid should be unique for a particular Poll."""
+        poll = factories.Poll()
+        factories.Question(poll=poll, ruleset_uuid='abc')
+        with self.assertRaises(IntegrityError):
+            factories.Question(poll=poll, ruleset_uuid='abc')
+
+    def test_ruleset_uuid_can_repeat_between_polls(self):
+        """ruleset_uuid can be repeated with different Polls."""
+        factories.Question(poll=factories.Poll(), ruleset_uuid='abc')
+        factories.Question(poll=factories.Poll(), ruleset_uuid='abc')
 
 
 class PollRunTest(TracProDataTest):
@@ -351,7 +606,7 @@ class PollRunTest(TracProDataTest):
             [('مطر', 1)])
 
 
-class ResponseTest(TracProDataTest):
+class TestResponse(TracProDataTest):
 
     def test_from_run(self):
         # a complete run
@@ -392,6 +647,7 @@ class ResponseTest(TracProDataTest):
             datetime.datetime(2015, 1, 2, 3, 4, 5, 6, pytz.UTC))
         self.assertEqual(response1.status, Response.STATUS_COMPLETE)
         self.assertEqual(len(response1.answers.all()), 2)
+
         answers = list(response1.answers.order_by('question_id'))
         self.assertEqual(answers[0].question, self.poll1_question1)
         self.assertEqual(answers[0].value, "6.00000000")
@@ -517,7 +773,7 @@ class ResponseTest(TracProDataTest):
         self.assertEqual(Response.from_run(self.unicef, run), response5)
 
 
-class AnswerTest(TracProDataTest):
+class TestAnswer(TracProDataTest):
 
     def test_create(self):
         pollrun = factories.UniversalPollRun(

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -10,7 +10,7 @@ from dash.utils import datetime_to_ms, get_obj_cacheable
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import (
-    HttpResponse, HttpResponseBadRequest, HttpResponseRedirect, JsonResponse)
+    HttpResponse, HttpResponseBadRequest, JsonResponse)
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 
@@ -114,7 +114,7 @@ class PollCRUDL(smartmin.SmartCRUDL):
 
     class Select(OrgPermsMixin, smartmin.SmartFormView):
         title = _("Poll Flows")
-        form_class = forms.FlowsForm
+        form_class = forms.ActivePollsForm
         success_url = '@polls.poll_list'
         submit_button_name = _("Update")
         success_message = _("Updated flows to track as polls")
@@ -125,8 +125,8 @@ class PollCRUDL(smartmin.SmartCRUDL):
             return kwargs
 
         def form_valid(self, form):
-            Poll.sync_with_flows(self.request.org, form.cleaned_data['flows'])
-            return HttpResponseRedirect(self.get_success_url())
+            form.save()
+            return super(PollCRUDL.Select, self).form_valid(form)
 
 
 class PollRunListMixin(object):

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -33,7 +33,7 @@ class PollCRUDL(smartmin.SmartCRUDL):
 
         def get_queryset(self):
             """Only allow viewing active polls for the current org."""
-            return Poll.get_all(self.request.org)
+            return Poll.objects.active().by_org(self.request.org)
 
     class Read(PollMixin, OrgObjPermsMixin, smartmin.SmartReadView):
 
@@ -209,7 +209,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             try:
-                poll = Poll.get_all(self.request.org).get(pk=request.POST.get('poll'))
+                poll = Poll.objects.active().by_org(self.request.org).get(pk=request.POST.get('poll'))
             except Poll.DoesNotExist:
                 return HttpResponseBadRequest()
 
@@ -384,7 +384,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
 
         def derive_poll(self):
             def fetch():
-                poll_qs = Poll.get_all(self.request.org)
+                poll_qs = Poll.objects.active().by_org(self.request.org)
                 return get_object_or_404(poll_qs, pk=self.kwargs['poll'])
             return get_obj_cacheable(self, '_poll', fetch)
 

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -589,7 +589,7 @@ class ResponseCRUDL(smartmin.SmartCRUDL):
                 return '<i>%s</i>' % _("No response")
 
             questions = obj.pollrun.poll.questions.active()
-            for question in questions:
+            for i, question in enumerate(questions, start=1):
                 answer = answers_by_q_id.get(question.pk, None)
                 if not answer:
                     answer_display = ""
@@ -599,7 +599,7 @@ class ResponseCRUDL(smartmin.SmartCRUDL):
                     answer_display = answer.category
 
                 answers.append("%d. %s: <em>%s</em>" % (
-                    question.order, question.name, answer_display))
+                    i, question.name, answer_display))
 
             return "<br/>".join(answers)
 

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -78,6 +78,7 @@ class PollCRUDL(smartmin.SmartCRUDL):
     class Update(PollMixin, OrgObjPermsMixin, smartmin.SmartUpdateView):
         form_class = forms.PollForm
         formset_class = forms.QuestionFormSet
+        success_url = 'id@polls.poll_read'
 
         def dispatch(self, *args, **kwargs):
             self.object = self.get_object()

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -40,8 +40,7 @@ class PollCRUDL(smartmin.SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super(PollCRUDL.Read, self).get_context_data(**kwargs)
             questions = self.object.questions.active()
-            pollruns = self.object.get_pollruns(
-                self.request.org,
+            pollruns = self.object.pollruns.active().by_region(
                 self.request.region,
                 self.request.include_subregions)
 
@@ -121,8 +120,7 @@ class PollCRUDL(smartmin.SmartCRUDL):
         default_order = ('name',)
 
         def derive_pollruns(self, obj):
-            return obj.get_pollruns(
-                self.request.org,
+            return obj.pollruns.active().by_region(
                 self.request.region,
                 self.request.include_subregions)
 
@@ -389,8 +387,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
             return get_obj_cacheable(self, '_poll', fetch)
 
         def derive_queryset(self, **kwargs):
-            return self.derive_poll().get_pollruns(
-                self.request.org,
+            return self.derive_poll().pollruns.active().by_region(
                 self.request.region,
                 self.request.include_subregions)
 

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -249,8 +249,8 @@ CELERYBEAT_SCHEDULE = {
         'schedule': datetime.timedelta(minutes=30),
         'args': (),
     },
-    'sync-fields': {
-        'task': 'tracpro.contacts.tasks.sync_all_fields',
+    'sync-data-fields': {
+        'task': 'tracpro.contacts.tasks.sync_all_data_fields',
         'schedule': datetime.timedelta(days=1),
         'args': (),
     },

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -244,6 +244,11 @@ ANONYMOUS_USER_ID = -1
 BROKER_URL = CELERY_RESULT_BACKEND = 'redis://localhost:6379/4'
 
 CELERYBEAT_SCHEDULE = {
+    'sync-polls': {
+        'task': 'tracpro.polls.tasks.sync_all_polls',
+        'schedule': datetime.timedelta(minutes=5),
+        'args': (),
+    },
     'sync-contacts': {
         'task': 'tracpro.contacts.tasks.sync_all_contacts',
         'schedule': datetime.timedelta(minutes=30),

--- a/tracpro/templates/polls/poll_read.html
+++ b/tracpro/templates/polls/poll_read.html
@@ -44,7 +44,7 @@
   </div>
   {% for question in questions %}
     <h3>
-      {{ question.order }}. {{ question.name }}:
+      {{ forloop.counter }}. {{ question.name }}:
       <span id="question-{{ question.pk }}-heading-value-type">{{ value_type_selected|title }}</span>
     </h3>
 

--- a/tracpro/templates/polls/poll_read.html
+++ b/tracpro/templates/polls/poll_read.html
@@ -44,7 +44,7 @@
   </div>
   {% for question in questions %}
     <h3>
-      {{ question.order }}. {{ question.text }}:
+      {{ question.order }}. {{ question.name }}:
       <span id="question-{{ question.pk }}-heading-value-type">{{ value_type_selected|title }}</span>
     </h3>
 
@@ -66,7 +66,7 @@
               series: [
                   {
                   type: 'area',
-                  name: '{{ question.text }}',
+                  name: '{{ question.name }}',
                   {% if value_type_selected|lower ==  "sum" %}
                     data: {{ question.answer_sum_list }}
                   {% elif value_type_selected|lower ==  "average" %}

--- a/tracpro/templates/polls/poll_update.html
+++ b/tracpro/templates/polls/poll_update.html
@@ -2,14 +2,29 @@
 
 {% load smartmin %}
 
-{% block post-fields %}
+{% block fields %}
+  <div class="form-group{% if form.name.errors %} error{% endif %}">
+    <label class="col-sm-2 control-label" for="{{ form.name.id_for_label }}">
+      {{ form.name.label }}
+    </label>
+    <div class="col-sm-10 smartmin-form-field">
+      {{ form.name|add_css:"form-control" }}
+    </div>
+    {% if object.rapidpro_name and object.rapidpro_name != object.name %}
+      <div class="col-sm-12 col-sm-offset-2 help-block">
+        <em>On RapidPro: {{ object.rapidpro_name }}</em>
+      </div>
+    {% endif %}
+  </div>
+
   {{ questions_formset.management_form }}
 
   {% for question_form in questions_formset %}
+  {% with question_form.instance as question %}
     <hr>
 
     <h4 class="text-muted">
-      Question: {{ question_form.instance.name }}
+      Question: {{ question.name }}
     </h4>
 
     {{ question_form.id }} {# Hidden field to identify question. #}
@@ -22,6 +37,11 @@
       <div class="col-sm-10 smartmin-form-field">
         {{ question_form.name|add_css:"form-control" }}
       </div>
+      {% if question.rapidpro_name and question.rapidpro_name != question.name %}
+        <div class="col-sm-12 col-sm-offset-2 help-block">
+          <em>On RapidPro: {{ question.rapidpro_name }}</em>
+        </div>
+      {% endif %}
     </div>
 
     <!-- Question type -->
@@ -45,5 +65,6 @@
         </div>
       </div>
     </div>
+  {% endwith %}
   {% endfor %}
-{% endblock post-fields %}
+{% endblock fields %}

--- a/tracpro/templates/polls/poll_update.html
+++ b/tracpro/templates/polls/poll_update.html
@@ -1,0 +1,49 @@
+{% extends "smartmin/update.html" %}
+
+{% load smartmin %}
+
+{% block post-fields %}
+  {{ questions_formset.management_form }}
+
+  {% for question_form in questions_formset %}
+    <hr>
+
+    <h4 class="text-muted">
+      Question: {{ question_form.instance.name }}
+    </h4>
+
+    {{ question_form.id }} {# Hidden field to identify question. #}
+
+    <!-- Question name -->
+    <div class="form-group{% if question_form.name.errors %} error{% endif %}">
+      <label class="col-sm-2 control-label" for="{{ question_form.name.id_for_label }}">
+        {{ question_form.name.label }}
+      </label>
+      <div class="col-sm-10 smartmin-form-field">
+        {{ question_form.name|add_css:"form-control" }}
+      </div>
+    </div>
+
+    <!-- Question type -->
+    <div class="form-group{% if question_form.question_type.errors %} error{% endif %}">
+      <label class="col-sm-2 control-label" for="{{ question_form.question_type.id_for_label }}">
+        {{ question_form.question_type.label }}
+      </label>
+      <div class="col-sm-6 smartmin-form-field">
+        {{ question_form.question_type|add_css:"form-control" }}
+      </div>
+    </div>
+
+    <!-- Question is_active -->
+    <div class="form-group{% if question_form.is_active.errors %} error{% endif %}">
+      <div class="col-sm-offset-2 col-sm-10">
+        <div class="checkbox">
+          <label for="{{ question_form.is_active.id_for_label }}">
+            {{ question_form.is_active }}
+            {{ question_form.is_active.label }}
+          </label>
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+{% endblock post-fields %}

--- a/tracpro/templates/polls/pollrun_read.html
+++ b/tracpro/templates/polls/pollrun_read.html
@@ -11,10 +11,10 @@
 
   {% for question in questions %}
     <h3>
-      {{ question.order }}. {{ question.text }}
+      {{ question.order }}. {{ question.name }}
 
     </h3>
-    <div class='chart' data-chart-type='{{ question.chart_type }}' data-unit-text='{{ question.text }}' data-question-id='{{ question.pk }}' dir='ltr'></div>
+    <div class='chart' data-chart-type='{{ question.chart_type }}' data-unit-text='{{ question.name }}' data-question-id='{{ question.pk }}' dir='ltr'></div>
     <script type='text/javascript'>
       var chart_{{ question.pk }}_data = {{ question.chart_data }};
 

--- a/tracpro/templates/polls/pollrun_read.html
+++ b/tracpro/templates/polls/pollrun_read.html
@@ -1,24 +1,23 @@
 {% extends "smartmin/base.html" %}
-{% load smartmin i18n %}
+
+{% load smartmin %}
+{% load i18n %}
 
 {% block pre-content %}
-
   {% include 'polls/pollrun_header.html' with pollrun=object %}
-
-{% endblock %}
+{% endblock pre-content %}
 
 {% block content %}
-
   {% for question in questions %}
-    <h3>
-      {{ question.order }}. {{ question.name }}
+    <h3>{{ forloop.counter }}. {{ question.name }}</h3>
 
-    </h3>
-    <div class='chart' data-chart-type='{{ question.chart_type }}' data-unit-text='{{ question.name }}' data-question-id='{{ question.pk }}' dir='ltr'></div>
+    <div class="chart"
+         data-chart-type="{{ question.chart_type }}"
+         data-unit-text="{{ question.name }}"
+         data-question-id="{{ question.pk }}"
+         dir="ltr"></div>
     <script type='text/javascript'>
       var chart_{{ question.pk }}_data = {{ question.chart_data }};
-
     </script>
   {% endfor %}
-{% endblock %}
-
+{% endblock content %}

--- a/tracpro/test/cases.py
+++ b/tracpro/test/cases.py
@@ -155,16 +155,15 @@ class TracProDataTest(TracProTest):
             org=self.unicef, name="Farm Poll", flow_uuid='F-001')
         self.poll1_question1 = factories.Question(
             poll=self.poll1,
-            type=Question.TYPE_NUMERIC,
-            text="Number of sheep",
+            question_type=Question.TYPE_NUMERIC,
+            name="Number of sheep",
             order=1,
             ruleset_uuid='RS-001',
         )
-
         self.poll1_question2 = factories.Question(
             poll=self.poll1,
-            type=Question.TYPE_OPEN,
-            text="How is the weather?",
+            question_type=Question.TYPE_OPEN,
+            name="How is the weather?",
             order=2,
             ruleset_uuid='RS-002',
         )
@@ -174,8 +173,8 @@ class TracProDataTest(TracProTest):
             org=self.nyaruka, name="Code Poll", flow_uuid='F-002')
         self.poll2_question1 = factories.Question(
             poll=self.poll2,
-            type=Question.TYPE_NUMERIC,
-            text="Number of bugs",
+            question_type=Question.TYPE_NUMERIC,
+            name="Number of bugs",
             order=1,
             ruleset_uuid='RS-003',
         )

--- a/tracpro/test/factories.py
+++ b/tracpro/test/factories.py
@@ -1,3 +1,4 @@
+from tracpro.test.temba_factories import *  # noqa
 from tracpro.contacts.tests.factories import *  # noqa
 from tracpro.groups.tests.factories import *  # noqa
 from tracpro.orgs_ext.tests.factories import *  # noqa

--- a/tracpro/test/factory_utils.py
+++ b/tracpro/test/factory_utils.py
@@ -13,7 +13,7 @@ class FuzzyEmail(factory.fuzzy.FuzzyText):
 class FuzzyUUID(factory.fuzzy.BaseFuzzyAttribute):
 
     def fuzz(self):
-        return uuid.uuid4()
+        return str(uuid.uuid4())
 
 
 class SmartModelFactory(factory.django.DjangoModelFactory):

--- a/tracpro/test/temba_factories.py
+++ b/tracpro/test/temba_factories.py
@@ -1,0 +1,44 @@
+import datetime
+
+import factory
+import factory.fuzzy
+
+from temba_client import types
+
+from .factory_utils import FuzzyUUID
+
+
+__all__ = ['TembaFlow', 'TembaRuleSet']
+
+
+class TembaObjectFactory(factory.Factory):
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        return model_class.create(*args, **kwargs)
+
+
+class TembaFlow(TembaObjectFactory):
+    uuid = FuzzyUUID()
+    name = factory.fuzzy.FuzzyText()
+    archived = False
+    participants = 0
+    runs = 0
+    completed_runs = 0
+    rulesets = []
+    created_on = factory.LazyAttribute(lambda o: datetime.datetime.now())
+
+    class Meta:
+        model = types.Flow
+
+
+class TembaRuleSet(TembaObjectFactory):
+    uuid = FuzzyUUID()
+    label = factory.fuzzy.FuzzyText()
+    response_type = factory.fuzzy.FuzzyChoice(['C', 'O', 'N'])
+
+    class Meta:
+        model = types.RuleSet


### PR DESCRIPTION
* Track all Polls and Questions regardless of whether they are active, similar to DataField. (Note: we still only track responses for active polls.)
* Use formsets to edit `Question.question_type` and `Question.is_active` 
* Better tracking of custom name vs RapidPro name. Question/Poll names will update when the corresponding item on RapidPro is updated, unless a customization has been applied.

Before testing, make sure to run `sync_all_polls`.