### PR TITLE
Question type updates

### DIFF
--- a/tracpro/contacts/tests/test_models.py
+++ b/tracpro/contacts/tests/test_models.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 import datetime
 from decimal import Decimal
 
-import mock
 import pytz
 
 from temba_client.types import Contact as TembaContact
@@ -26,9 +25,8 @@ class ContactTest(TracProDataTest):
         CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
         BROKER_BACKEND='memory',
     )
-    @mock.patch('dash.orgs.models.TembaClient.create_contact')
-    def test_create(self, mock_create_contact):
-        mock_create_contact.return_value = TembaContact.create(
+    def test_create(self):
+        self.mock_temba_client.create_contact.return_value = TembaContact.create(
             uuid='C-007',
             name="Mo Polls",
             urns=['tel:078123'],
@@ -64,11 +62,10 @@ class ContactTest(TracProDataTest):
         contact.refresh_from_db()
         self.assertEqual(contact.uuid, 'C-007')
 
-        self.assertEqual(mock_create_contact.call_count, 1)
+        self.assertEqual(self.mock_temba_client.create_contact.call_count, 1)
 
-    @mock.patch('dash.orgs.models.TembaClient.get_contact')
-    def test_get_or_fetch(self, mock_get_contact):
-        mock_get_contact.return_value = TembaContact.create(
+    def test_get_or_fetch(self):
+        self.mock_temba_client.get_contact.return_value = TembaContact.create(
             uuid='C-007', name="Mo Polls",
             urns=['tel:078123'], groups=['G-001', 'G-005'],
             fields={},
@@ -149,12 +146,11 @@ class ContactTest(TracProDataTest):
         CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
         BROKER_BACKEND='memory',
     )
-    @mock.patch('dash.orgs.models.TembaClient.delete_contact')
-    def test_delete(self, mock_delete_contact):
+    def test_delete(self):
         self.contact1.delete()
         self.assertFalse(self.contact1.is_active)
 
-        self.assertEqual(mock_delete_contact.call_count, 1)
+        self.assertEqual(self.mock_temba_client.delete_contact.call_count, 1)
 
     def test_str(self):
         self.assertEqual(str(self.contact1), "Ann")

--- a/tracpro/contacts/tests/test_views.py
+++ b/tracpro/contacts/tests/test_views.py
@@ -1,6 +1,6 @@
 import json
 
-from temba_client.types import Run
+from temba_client.types import Contact as TembaContact, Run
 
 from django.core.urlresolvers import reverse
 from django.utils import timezone
@@ -34,6 +34,9 @@ class ContactCRUDLTest(TracProDataTest):
         self.assertFormError(response, 'form', 'group', 'This field is required.')
 
         # submit again with all fields
+        temba_contact = TembaContact()
+        temba_contact.uuid = "uuid"
+        self.mock_temba_client.create_contact.return_value = temba_contact
         response = self.url_post('unicef', url, {
             'name': "Mo Polls",
             'urn_0': "tel",
@@ -43,6 +46,7 @@ class ContactCRUDLTest(TracProDataTest):
             'language': 'eng',
         })
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.mock_temba_client.create_contact.call_count, 1)
 
         # check new contact and profile
         contact = Contact.objects.get(urn='tel:5678')

--- a/tracpro/msgs/tests/test_models.py
+++ b/tracpro/msgs/tests/test_models.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-from mock import patch
-
 from django.test.utils import override_settings
 from django.utils import timezone
 
@@ -21,9 +19,8 @@ class MessageTest(TracProDataTest):
         CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
         BROKER_BACKEND='memory',
     )
-    @patch('dash.orgs.models.TembaClient.create_broadcast')
-    def test_create(self, mock_create_broadcast):
-        mock_create_broadcast.return_value = Broadcast.create()
+    def test_create(self):
+        self.mock_temba_client.create_broadcast.return_value = Broadcast.create()
         now = timezone.now()
 
         # create non-regional pollrun with 3 responses (1 complete, 1 partial, 1 empty)

--- a/tracpro/polls/migrations/0030_reset_question_types.py
+++ b/tracpro/polls/migrations/0030_reset_question_types.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from temba_client.client import TembaClient
+
+from django.conf import settings
+from django.db import migrations
+
+
+NUMERIC_TESTS = ('number', 'lt', 'eq', 'gt', 'between')
+
+
+def get_temba_client(org):
+    host = settings.SITE_API_HOST
+    user_agent = settings.SITE_API_USER_AGENT
+    return TembaClient(host=host, user_agent=user_agent, token=org.api_token)
+
+
+def guess_question_type_from_rules(apps, schema_editor):
+    """Guess question type from the tests applied to question input."""
+    for org in apps.get_model('orgs', 'Org').objects.all():
+        client = get_temba_client(org)
+        for poll in org.polls.all():
+            rulesets = client.get_flow_definition(poll.flow_uuid).rule_sets
+            rules_by_ruleset_uuid = {r['uuid']: r['rules'] for r in rulesets}
+            for question in poll.questions.all():
+                rules = rules_by_ruleset_uuid.get(question.ruleset_uuid)
+                tests = [r['test']['type'] for r in rules] if rules else []
+                tests = tests[:-1]  # The last test is always "Other"
+                if not tests:
+                    question.question_type = 'O'
+                elif all(t in NUMERIC_TESTS for t in tests):
+                    question.question_type = 'N'
+                else:
+                    question.question_type = 'C'
+                question.save()
+
+
+def set_question_type_from_response_type(apps, schema_editor):
+    """Reset question type from ruleset response type."""
+    for org in apps.get_model('orgs', 'Org').objects.all():
+        client = get_temba_client(org)
+        for poll in org.polls.all():
+            rulesets = client.get_flow(poll.flow_uuid).rulesets
+            rulesets_by_uuid = {r.uuid: r for r in rulesets}
+            for question in poll.questions.all():
+                ruleset = rulesets_by_uuid.get(question.ruleset_uuid)
+                if ruleset:
+                    question.question_type = ruleset.response_type
+                    question.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('polls', '0029_poll_tweaks'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            guess_question_type_from_rules,
+            set_question_type_from_response_type),
+    ]

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -149,6 +149,16 @@ class Poll(models.Model):
     def __str__(self):
         return self.name
 
+    def get_flow_definition(self):
+        """Retrieve extra metadata about the RapidPro flow."""
+        if not hasattr(self, '_flow_definition'):
+            # NOTE: Flow definition endpoint is not documented in the
+            # RapidPro API docs.
+            client = self.org.get_temba_client()
+            definition = client.get_flow_definition(self.flow_uuid)
+            self._flow_definition = definition
+        return self._flow_definition
+
     def save(self, *args, **kwargs):
         """Don't save custom name if it is the same as the RapidPro name.
 
@@ -169,7 +179,7 @@ class QuestionManager(models.Manager.from_queryset(QuestionQuerySet)):
 
     def from_temba(self, poll, temba_question, order):
         """Create new or update existing Question from RapidPro data."""
-        question, created = self.get_or_create(poll=poll, ruleset_uuid=temba_question.uuid)
+        question, _ = self.get_or_create(poll=poll, ruleset_uuid=temba_question.uuid)
 
         if question.name == question.rapidpro_name:
             # Name is tracking RapidPro name so we must update both.
@@ -178,12 +188,10 @@ class QuestionManager(models.Manager.from_queryset(QuestionQuerySet)):
             # Custom name will be maintained despite update of RapidPro name.
             question.rapidpro_name = temba_question.label
 
-        # NOTE: response_type appears to be deprecated in RapidPro.
-        # Already it returns from a reduced subset of former types.
-        # Because of this, we allow users to edit the question type
-        # after it is initially set.
-        if created:
-            question.question_type = temba_question.response_type
+        # The user can alter or correct the question's type after it is
+        # initially set, so we shouldn't override the existing type.
+        if not question.question_type:
+            question.question_type = question._guess_question_type()
 
         question.order = order
         question.save()
@@ -194,6 +202,9 @@ class QuestionManager(models.Manager.from_queryset(QuestionQuerySet)):
 @python_2_unicode_compatible
 class Question(models.Model):
     """Corresponds to RapidPro RuleSet."""
+    # Types of rules that RapidPro applies to incoming messages
+    # that suggest the expected data is numeric.
+    _NUMERIC_TESTS = ('number', 'lt', 'eq', 'gt', 'between')
 
     TYPE_OPEN = 'O'
     TYPE_MULTIPLE_CHOICE = 'C'
@@ -239,6 +250,27 @@ class Question(models.Model):
 
     def __str__(self):
         return self.name
+
+    def _guess_question_type(self):
+        """Inspect rules applied to question input to guess data type.
+
+        Historically, the "response_type" field on the ruleset was used to
+        determine question type. This field appears to have been deprecated
+        and currently returns from a limited subset of possible types.
+        """
+        # Collect the type of each test applied to question input, e.g.,
+        # "has any of these words", "has a number", "has a number between", etc.
+        defn = self.poll.get_flow_definition()
+        rules = {r['uuid']: r['rules'] for r in defn.rule_sets}.get(self.ruleset_uuid)
+        tests = [r['test']['type'] for r in rules] if rules else []
+        tests = tests[:-1]  # The last test is always "Other".
+
+        if not tests:
+            return self.TYPE_OPEN
+        elif all(t in self._NUMERIC_TESTS for t in tests):
+            return self.TYPE_NUMERIC
+        else:
+            return self.TYPE_MULTIPLE_CHOICE
 
     def save(self, *args, **kwargs):
         """Don't save custom name if it is the same as the RapidPro name.

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -169,7 +169,7 @@ class QuestionManager(models.Manager.from_queryset(QuestionQuerySet)):
 
     def from_temba(self, poll, temba_question, order):
         """Create new or update existing Question from RapidPro data."""
-        question, _ = self.get_or_create(poll=poll, ruleset_uuid=temba_question.uuid)
+        question, created = self.get_or_create(poll=poll, ruleset_uuid=temba_question.uuid)
 
         if question.name == question.rapidpro_name:
             # Name is tracking RapidPro name so we must update both.
@@ -180,7 +180,10 @@ class QuestionManager(models.Manager.from_queryset(QuestionQuerySet)):
 
         # NOTE: response_type appears to be deprecated in RapidPro.
         # Already it returns from a reduced subset of former types.
-        question.question_type = temba_question.response_type
+        # Because of this, we allow users to edit the question type
+        # after it is initially set.
+        if created:
+            question.question_type = temba_question.response_type
 
         question.order = order
         question.save()

--- a/tracpro/polls/tests/test_models.py
+++ b/tracpro/polls/tests/test_models.py
@@ -71,13 +71,18 @@ class TestPollManager(TracProTest):
     def test_set_active_for_org__invalid_uuids(self):
         """An error is raised when an invalid UUID for the org is passed."""
         org = factories.Org()
-        factories.Poll(org=org, is_active=False, flow_uuid='a')
+        poll = factories.Poll(org=org, is_active=False, flow_uuid='a')
 
         other_org = factories.Org()
-        factories.Poll(org=other_org, is_active=False, flow_uuid='b')
+        other_poll = factories.Poll(org=other_org, is_active=False, flow_uuid='b')
 
         with self.assertRaises(ValueError):
             Poll.objects.set_active_for_org(org, ['a', 'b'])
+
+        poll.refresh_from_db()
+        self.assertFalse(poll.is_active)
+        other_poll.refresh_from_db()
+        self.assertFalse(other_poll.is_active)
 
     def test_from_temba__existing(self):
         """Fields on an existing Poll should be updated from RapidPro."""


### PR DESCRIPTION
* Syncing a question with RapidPro should not overwrite the user-chosen question type.
* Guess the question type by inspecting the types of the rules in the associated ruleset.
* Mock the entire temba API client during tests.

The following code snippet can be run upon release to improve the accuracy of existing question types. I did not want to put this in a migration since it requires object methods which are not usually available in migrations.

```
from tracpro.polls.models import Poll
for poll in Poll.objects.all():
    for question in Question.objects.all():
        question.question_type = question._guess_question_type()
        question.save()
```