### PR TITLE
Require org subdomain

### DIFF
--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -39,6 +39,9 @@ class OrgExtForm(OrgForm):
         language.label = _("Default language")
         language.help_text = _("The default language for your organization")
 
+        # All orgs must use a subdomain.
+        self.fields['subdomain'].required = True
+
         # Config field values are not set automatically.
         self.fields['available_languages'].initial = self.instance.available_languages or []
         self.fields['show_spoof_data'].initial = self.instance.show_spoof_data or False

--- a/tracpro/orgs_ext/tests/test_forms.py
+++ b/tracpro/orgs_ext/tests/test_forms.py
@@ -31,8 +31,16 @@ class TestOrgExtForm(TestCase):
             'editors': [self.user.pk],
             'viewers': [self.user.pk],
             'administrators': [self.user.pk],
-            'show_spoof_data': True
+            'show_spoof_data': True,
+            'subdomain': 'org',
         }
+
+    def test_subdomain_required(self, mock_sync):
+        self.data.pop('subdomain')
+        form = self.form_class(data=self.data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors.keys(), ['subdomain'])
+        self.assertEqual(form.errors['subdomain'], ['This field is required.'])
 
     def test_available_languages_initial_for_create(self, mock_sync):
         """Available languages should default to empty list when creating an org."""
@@ -50,28 +58,23 @@ class TestOrgExtForm(TestCase):
         self.data.pop('language')
         form = self.form_class(data=self.data, instance=None)
         self.assertFalse(form.is_valid())
-        self.assertEqual(len(form.errors), 1, form.errors)
-        self.assertTrue('language' in form.errors, form.errors)
-        self.assertEqual(form.errors['language'],
-                         ['This field is required.'])
+        self.assertEqual(form.errors.keys(), ['language'])
+        self.assertEqual(form.errors['language'], ['This field is required.'])
 
     def test_default_language_required_for_update(self, mock_sync):
         """Form should require a default language when updating an org."""
         self.data.pop('language')
         form = self.form_class(data=self.data, instance=factories.Org())
         self.assertFalse(form.is_valid())
-        self.assertEqual(len(form.errors), 1, form.errors)
-        self.assertTrue('language' in form.errors, form.errors)
-        self.assertEqual(form.errors['language'],
-                         ['This field is required.'])
+        self.assertEqual(form.errors.keys(), ['language'])
+        self.assertEqual(form.errors['language'], ['This field is required.'])
 
     def test_available_languages_required_for_create(self, mock_sync):
         """Form should require available languages for new orgs."""
         self.data.pop('available_languages')
         form = self.form_class(data=self.data, instance=None)
         self.assertFalse(form.is_valid())
-        self.assertEqual(len(form.errors), 1, form.errors)
-        self.assertTrue('available_languages' in form.errors, form.errors)
+        self.assertEqual(form.errors.keys(), ['available_languages'])
         self.assertEqual(form.errors['available_languages'],
                          ['This field is required.'])
 
@@ -80,8 +83,7 @@ class TestOrgExtForm(TestCase):
         self.data.pop('available_languages')
         form = self.form_class(data=self.data, instance=factories.Org())
         self.assertFalse(form.is_valid())
-        self.assertEqual(len(form.errors), 1, form.errors)
-        self.assertTrue('available_languages' in form.errors, form.errors)
+        self.assertEqual(form.errors.keys(), ['available_languages'])
         self.assertEqual(form.errors['available_languages'],
                          ['This field is required.'])
 
@@ -90,12 +92,10 @@ class TestOrgExtForm(TestCase):
         self.data['language'] = 'fr'
         form = self.form_class(data=self.data)
         self.assertFalse(form.is_valid())
-        self.assertEqual(len(form.errors), 1, form.errors)
-        self.assertTrue(NON_FIELD_ERRORS in form.errors, form.errors)
+        self.assertEqual(form.errors.keys(), [NON_FIELD_ERRORS])
         self.assertEqual(form.errors[NON_FIELD_ERRORS],
                          ['Default language must be one of the languages '
-                          'available for this organization.'],
-                         form.errors)
+                          'available for this organization.'])
 
     def test_available_languages_no_change(self, mock_sync):
         """Form should allow available languages to remain unchanged."""
@@ -147,8 +147,7 @@ class TestOrgExtForm(TestCase):
         self.data['available_languages'] = ['es']
         form = self.form_class(data=self.data, instance=org)
         self.assertFalse(form.is_valid())
-        self.assertTrue(NON_FIELD_ERRORS in form.errors, form.errors)
+        self.assertTrue(form.errors.keys(), [NON_FIELD_ERRORS])
         self.assertEqual(form.errors[NON_FIELD_ERRORS],
                          ['Default language must be one of the languages '
-                          'available for this organization.'],
-                         form.errors)
+                          'available for this organization.'])


### PR DESCRIPTION
If an org's subdomain is the empty string, it is set as the request org when visiting a page on the global domain. (i.e., why we've been seeing "Somalia" on the top level of the staging site.)

This seems to be intentional behavior in Dash. But all of our orgs must be accessed through subdomains, so it seems logical to simply require that field when creating or editing an org.

