### PR TITLE
Back button bug fix for chart data

### DIFF
--- a/tracpro/templates/polls/poll_read.html
+++ b/tracpro/templates/polls/poll_read.html
@@ -142,8 +142,13 @@
           $("#question-{{ question.pk }}-heading-value-type").html("Response Rate");
         {% endfor %}
       }
-    }).change()
-    // Run this once on initial page load via .change(),
+    })
+
+    // Run this once on initial page load,
     // in the case that the user has hit the Back button.
+    $(function () {
+      $('#value-type-select').change();
+    });
+
 </script>
 {% endblock %}

--- a/tracpro/templates/polls/poll_read.html
+++ b/tracpro/templates/polls/poll_read.html
@@ -17,7 +17,7 @@
       <form class='form-inline' method='get'>
         <label class='control-label' for='window-select'></label>
         {% trans "Show" %}
-        <select id='value-type-select' class='form-control' onchange='onValueTypeChange()' name='value_type'>
+        <select id='value-type-select' class='form-control' name='value_type'>
           {% for value_type in value_type_options %}
             {% if value_type == value_type_selected %}
               <option selected='selected' value='{{ value_type }}'>{{ value_type }}</option>
@@ -26,7 +26,7 @@
             {% endif %}
           {% endfor %}
         </select>
-        <select id='window-select' class='form-control' onchange='onWindowChange(this)' name='window'>
+        <select id='window-select' class='form-control' name='window'>
           {% for win in window_options %}
             {% if win == window %}
               <option selected='selected' value='{{ win.name }}'>
@@ -116,19 +116,11 @@
   {% endfor %}
 
 <script>
-    $(function () {
-      // Run this once on initial page load,
-      // in the case that the user has hit the Back button.
-      onValueTypeChange();
+    $('#window-select').on('change', function() {
+      $('.form-inline').submit();
     });
-    function onWindowChange(ctrl) {
-      ctrl.form.submit();
-    }
-    function onValueTypeChange() {
-      valueType = $("#value-type-select :selected").text().toLowerCase();
-      changeChartValueType(valueType);
-    }
-    function changeChartValueType(valueType) {
+    $('#value-type-select').on('change', function() {
+      var valueType = $(this).val().toLowerCase();
       if (valueType == "sum") {
         {% for question in questions %}
           var chart = $('#chart_{{ question.pk }}').highcharts();
@@ -150,6 +142,8 @@
           $("#question-{{ question.pk }}-heading-value-type").html("Response Rate");
         {% endfor %}
       }
-    }
+    }).change()
+    // Run this once on initial page load via .change(),
+    // in the case that the user has hit the Back button.
 </script>
 {% endblock %}

--- a/tracpro/templates/polls/poll_read.html
+++ b/tracpro/templates/polls/poll_read.html
@@ -26,7 +26,6 @@
             {% endif %}
           {% endfor %}
         </select>
-        <input type="hidden" id="value-type-cache" value="">
         <select id='window-select' class='form-control' onchange='onWindowChange(this)' name='window'>
           {% for win in window_options %}
             {% if win == window %}
@@ -118,8 +117,8 @@
 
 <script>
     $(function () {
-      // Run this once, in the case that the user has
-      // hit the Back button.
+      // Run this once on initial page load,
+      // in the case that the user has hit the Back button.
       onValueTypeChange();
     });
     function onWindowChange(ctrl) {
@@ -128,8 +127,6 @@
     function onValueTypeChange() {
       valueType = $("#value-type-select :selected").text().toLowerCase();
       changeChartValueType(valueType);
-      // Keep track of this value in a "cached" hidden variable for Back button click
-      $("#value-type-cache").val(valueType);
     }
     function changeChartValueType(valueType) {
       if (valueType == "sum") {

--- a/tracpro/templates/polls/poll_read.html
+++ b/tracpro/templates/polls/poll_read.html
@@ -17,7 +17,7 @@
       <form class='form-inline' method='get'>
         <label class='control-label' for='window-select'></label>
         {% trans "Show" %}
-        <select id='value-type-select' class='form-control' onchange='onValueTypeChange(this)' name='value_type'>
+        <select id='value-type-select' class='form-control' onchange='onValueTypeChange()' name='value_type'>
           {% for value_type in value_type_options %}
             {% if value_type == value_type_selected %}
               <option selected='selected' value='{{ value_type }}'>{{ value_type }}</option>
@@ -26,6 +26,7 @@
             {% endif %}
           {% endfor %}
         </select>
+        <input type="hidden" id="value-type-cache" value="">
         <select id='window-select' class='form-control' onchange='onWindowChange(this)' name='window'>
           {% for win in window_options %}
             {% if win == window %}
@@ -114,37 +115,44 @@
     {% endif %}
 
   {% endfor %}
-{% endblock %}
-{% block extra-script %}
-<script type='text/javascript'>
-    // <![CDATA[
+
+<script>
+    $(function () {
+      // Run this once, in the case that the user has
+      // hit the Back button.
+      onValueTypeChange();
+    });
     function onWindowChange(ctrl) {
       ctrl.form.submit();
     }
-    function onValueTypeChange(ctrl) {
+    function onValueTypeChange() {
       valueType = $("#value-type-select :selected").text().toLowerCase();
+      changeChartValueType(valueType);
+      // Keep track of this value in a "cached" hidden variable for Back button click
+      $("#value-type-cache").val(valueType);
+    }
+    function changeChartValueType(valueType) {
       if (valueType == "sum") {
-          {% for question in questions %}
-            var chart = $('#chart_{{ question.pk }}').highcharts();
-            chart.series[0].setData({{ question.answer_sum_dict_list|safe }});
-            $("#question-{{ question.pk }}-heading-value-type").html("Sum");
-          {% endfor %}
+        {% for question in questions %}
+          var chart = $('#chart_{{ question.pk }}').highcharts();
+          chart.series[0].setData({{ question.answer_sum_dict_list|safe }});
+          $("#question-{{ question.pk }}-heading-value-type").html("Sum");
+        {% endfor %}
       }
       else if (valueType == "average") {
-          {% for question in questions %}
-            var chart = $('#chart_{{ question.pk }}').highcharts();
-            chart.series[0].setData({{ question.answer_average_dict_list|safe }});
-            $("#question-{{ question.pk }}-heading-value-type").html("Average");
-          {% endfor %}
+        {% for question in questions %}
+          var chart = $('#chart_{{ question.pk }}').highcharts();
+          chart.series[0].setData({{ question.answer_average_dict_list|safe }});
+          $("#question-{{ question.pk }}-heading-value-type").html("Average");
+        {% endfor %}
       }
       else if (valueType == "response rate") {
-          {% for question in questions %}
-            var chart = $('#chart_{{ question.pk }}').highcharts();
-            chart.series[0].setData({{ question.response_rate_dict_list|safe }});
-            $("#question-{{ question.pk }}-heading-value-type").html("Response Rate");
-          {% endfor %}
+        {% for question in questions %}
+          var chart = $('#chart_{{ question.pk }}').highcharts();
+          chart.series[0].setData({{ question.response_rate_dict_list|safe }});
+          $("#question-{{ question.pk }}-heading-value-type").html("Response Rate");
+        {% endfor %}
       }
     }
-    // ]]>
 </script>
 {% endblock %}


### PR DESCRIPTION
Issue described in https://basecamp.com/1849796/projects/9585844/messages/52475672, copied below:

"one thing i noticed is that the filters are a bit funky if you change from sum to response rate, click and poll date, and then use the back button to return to the poll summary (e.g. https://zimbabwe.edutrac-staging.cakt.us/poll/read/42/). it will display sum, but the filter still shows response rate"

Update: 
This fix calls the onValueTypeChange() function on initial page load so that when the user clicks the Back button, the correct charts are loaded.