### PR TITLE
PollRun Participation tab display participating groups/regions only

### DIFF
--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -309,8 +309,7 @@ class PollRunCRUDL(smartmin.SmartCRUDL):
                     overall_counts['E'] = overall_counts['E'] + per_group_counts[group_or_region]['E']
                     overall_counts['P'] = overall_counts['P'] + per_group_counts[group_or_region]['P']
                     overall_counts['C'] = overall_counts['C'] + per_group_counts[group_or_region]['C']
-                else:
-                    per_group_counts[group_or_region] = {'E': 0, 'P': 0, 'C': 0}
+
             # Calculate all no-group or no-region activity
             if group_by_reporter_group:
                 responses_no_group = responses.filter(contact__group__isnull=True)


### PR DESCRIPTION
Removing line that adds non-participating groups/regions to the participation dictionary.

Fixes https://trello.com/c/iZqoS4FI/92-check-to-see-if-participation-tab-on-pollrun-detail-page-is-displaying-groups-that-were-not-sent-poll-do-not-display-these-group