### PR TITLE
Filter refactoring

### DIFF
--- a/tracpro/polls/charts.py
+++ b/tracpro/polls/charts.py
@@ -182,14 +182,15 @@ def multiple_pollruns_numeric(pollruns, question, regions):
         answer_average_dict_list = []
         response_rate_dict_list = []
         for z in zip(answer_sum_list, answer_average_list, response_rate_list, pollrun_list):
-            pollrun_link_read = reverse('polls.pollrun_read', args=[str(z[3])])
-            pollrun_link_participation = reverse('polls.pollrun_participation', args=[str(z[3])])
+            answer_sum, answer_average, response_rate, pollrun_id = z
+            pollrun_detail = reverse('polls.pollrun_read', args=[pollrun_id])
+            pollrun_participation = reverse('polls.pollrun_participation', args=[pollrun_id])
             answer_sum_dict_list.append(
-                {str('y'): z[0], str('url'): pollrun_link_read})
+                {'y': answer_sum, 'url': pollrun_detail})
             answer_average_dict_list.append(
-                {str('y'): z[1], str('url'): pollrun_link_read})
+                {'y': answer_average, 'url': pollrun_detail})
             response_rate_dict_list.append(
-                {str('y'): z[2], str('url'): pollrun_link_participation})
+                {'y': response_rate, 'url': pollrun_participation})
 
         question.answer_mean = round(numpy.mean(answer_average_list), 2)
         question.answer_stdev = round(numpy.std(answer_average_list), 2)

--- a/tracpro/polls/charts.py
+++ b/tracpro/polls/charts.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import cgi
-from collections import defaultdict
 import datetime
 from decimal import Decimal
 from itertools import groupby
@@ -75,16 +74,13 @@ def multiple_pollruns(pollruns, question, regions):
 
 def multiple_pollruns_open(pollruns, question, regions):
     """Chart data for multiple pollruns of a poll."""
-    # {'word1': 50, 'word2': 9, ...}
-    counts = defaultdict(int)
-    for pollrun in pollruns:
-        for word, count in pollrun.get_answer_word_counts(question, regions):
-            counts[word] += count
-
-    if counts:
-        sorted_counts = sorted(counts.items(), key=itemgetter(1), reverse=True)
-        return word_cloud_data(sorted_counts[:50])
-    return None
+    answers = Answer.objects.filter(
+        response__pollrun__in=pollruns,
+        response__is_active=True,
+        question=question)
+    if regions:
+        answers = answers.filter(response__contact__region__in=regions)
+    return word_cloud_data(answers.word_counts()) if answers else None
 
 
 def multiple_pollruns_multiple_choice(pollruns, question, regions):

--- a/tracpro/polls/forms.py
+++ b/tracpro/polls/forms.py
@@ -72,7 +72,7 @@ class ChartFilterForm(forms.Form):
         ('custom', _("Custom range...")),
     )
 
-    data_type = forms.ChoiceField(
+    num_display = forms.ChoiceField(
         label=_("Numeric display"),
         help_text=_("How responses to numeric questions will be charted."),
         choices=NUMERIC_DATA_CHOICES)
@@ -93,7 +93,7 @@ class ChartFilterForm(forms.Form):
     def __init__(self, *args, **kwargs):
         start_date, end_date = get_month_range()
         kwargs.setdefault('initial', {
-            'data_type': 'sum',
+            'num_display': 'sum',
             'date_range': 'month',
             'start_date': start_date,
             'end_date': end_date,

--- a/tracpro/polls/forms.py
+++ b/tracpro/polls/forms.py
@@ -77,12 +77,15 @@ class ChartFilterForm(forms.Form):
         help_text=_("How responses to numeric questions will be charted."),
         choices=NUMERIC_DATA_CHOICES)
     date_range = forms.ChoiceField(
+        label=_("Date range"),
         choices=DATE_WINDOW_CHOICES)
     start_date = forms.DateTimeField(
+        label=_("Start date"),
         required=False,
         widget=forms.widgets.DateInput(attrs={'class': 'datepicker'}),
         error_messages={'invalid': "Please enter a valid date."})
     end_date = forms.DateTimeField(
+        label=_("End date"),
         required=False,
         widget=forms.widgets.DateInput(attrs={'class': 'datepicker'}),
         error_messages={'invalid': "Please enter a valid date."})

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -773,7 +773,7 @@ class AnswerQuerySet(models.QuerySet):
                     dates.append(response_date)
                     pollrun_list.append(pollrun_pk)
                 response_date = answer.response.created_on.date()
-                pollrun_pk = answer.response.pollrun.pk
+                pollrun_pk = answer.response.pollrun_id
                 total = float(0)
                 total_answers = 0
             try:

--- a/tracpro/polls/tests/test_charts.py
+++ b/tracpro/polls/tests/test_charts.py
@@ -71,7 +71,6 @@ class PollChartTest(TracProDataTest):
         self.assertEqual(data['series'], [
             {'name': u'1 - 5', 'data': [2]},
             {'name': u'6 - 10', 'data': [1]},
-            {'name': None, 'data': [3]},
         ])
 
     def test_multiple_pollruns_open(self):

--- a/tracpro/polls/tests/test_forms.py
+++ b/tracpro/polls/tests/test_forms.py
@@ -32,7 +32,7 @@ class TestChartFilterForm(TracProTest):
 
         # Data to pass to form for testing.
         self.data = {
-            'data_type': 'response-rate',
+            'num_display': 'response-rate',
             'date_range': 'custom',
             'start_date': datetime.datetime(2014, 1, 15, tzinfo=pytz.UTC),
             'end_date': datetime.datetime(2014, 10, 22, tzinfo=pytz.UTC),
@@ -40,7 +40,7 @@ class TestChartFilterForm(TracProTest):
 
         # Expected initial values.
         self.expected_initial = {
-            'data_type': 'sum',
+            'num_display': 'sum',
             'date_range': 'month',
             'start_date': datetime.datetime(2016, 2, 1, tzinfo=pytz.UTC),
             'end_date': datetime.datetime(2016, 2, 29, tzinfo=pytz.UTC),
@@ -81,7 +81,7 @@ class TestChartFilterForm(TracProTest):
         self.assertFalse(form.is_valid())
         for field in self.data.keys():
             with self.assertRaises(ValueError):
-                form.get_value('data_type')
+                form.get_value('num_display')
 
     def test_get_value__field_nonexistant(self):
         """get_value() should raise a KeyError if requested field is not in form."""
@@ -96,23 +96,23 @@ class TestChartFilterForm(TracProTest):
         for field, value in self.data.items():
             self.assertEqual(form.get_value(field), value)
 
-    def test_data_type_required(self):
+    def test_num_display_required(self):
         """Data type choice is required."""
-        self.data.pop('data_type')
+        self.data.pop('num_display')
         form = forms.ChartFilterForm(data=self.data)
         self.assertFalse(form.is_valid())
         self.assertDictEqual(form.errors, {
-            'data_type': ['This field is required.'],
+            'num_display': ['This field is required.'],
         })
 
-    def test_data_type_invalid(self):
+    def test_num_display_invalid(self):
         """Data type must come from list of valid choices."""
-        self.data['data_type'] = 'invalid'
+        self.data['num_display'] = 'invalid'
         form = forms.ChartFilterForm(data=self.data)
         self.assertFalse(form.is_valid())
         self.assertDictEqual(form.errors, {
-            'data_type': ['Select a valid choice. '
-                          'invalid is not one of the available choices.'],
+            'num_display': ['Select a valid choice. '
+                            'invalid is not one of the available choices.'],
         })
 
     def test_date_range_required(self):

--- a/tracpro/polls/tests/test_forms.py
+++ b/tracpro/polls/tests/test_forms.py
@@ -38,14 +38,6 @@ class TestChartFilterForm(TracProTest):
             'end_date': datetime.datetime(2014, 10, 22, tzinfo=pytz.UTC),
         }
 
-        # Expected initial values.
-        self.expected_initial = {
-            'num_display': 'sum',
-            'date_range': 'month',
-            'start_date': datetime.datetime(2016, 2, 1, tzinfo=pytz.UTC),
-            'end_date': datetime.datetime(2016, 2, 29, tzinfo=pytz.UTC),
-        }
-
     def tearDown(self):
         super(TestChartFilterForm, self).tearDown()
         self.month_range_patcher.stop()
@@ -61,40 +53,16 @@ class TestChartFilterForm(TracProTest):
         self.assertEqual(form.cleaned_data['end_date'], end_date)
 
     def test_initial(self):
-        """Initial values should be set for form fields."""
+        """Default data should be set if data is not passed to the form."""
         form = forms.ChartFilterForm()
-        for field, value in self.expected_initial.items():
-            self.assertIsNone(form.fields[field].initial)
-            self.assertEqual(form.initial[field], value)
-
-    def test_get_value__form_unbound(self):
-        """get_value() should return field's initial valid if form is unbound."""
-        form = forms.ChartFilterForm()
-        self.assertFalse(form.is_bound)
-        for field, value in self.expected_initial.items():
-            self.assertEqual(form.get_value(field), value)
-
-    def test_get_value__form_invalid(self):
-        """get_value() cannot be called on an invalid form."""
-        form = forms.ChartFilterForm(data={})
         self.assertTrue(form.is_bound)
-        self.assertFalse(form.is_valid())
-        for field in self.data.keys():
-            with self.assertRaises(ValueError):
-                form.get_value('num_display')
-
-    def test_get_value__field_nonexistant(self):
-        """get_value() should raise a KeyError if requested field is not in form."""
-        form = forms.ChartFilterForm(data=self.data)
         self.assertTrue(form.is_valid())
-        with self.assertRaises(KeyError):
-            form.get_value('invalid')
-
-    def test_get_value__form_valid(self):
-        """get_value() should return the passed-in value for a valid form."""
-        form = forms.ChartFilterForm(data=self.data)
-        for field, value in self.data.items():
-            self.assertEqual(form.get_value(field), value)
+        self.assertDictEqual(form.data, {
+            'num_display': 'sum',
+            'date_range': 'month',
+            'start_date': datetime.datetime(2016, 2, 1, tzinfo=pytz.UTC),
+            'end_date': datetime.datetime(2016, 2, 29, tzinfo=pytz.UTC),
+        })
 
     def test_num_display_required(self):
         """Data type choice is required."""

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -39,25 +39,20 @@ class PollCRUDL(smartmin.SmartCRUDL):
 
         def get(self, request, *args, **kwargs):
             self.object = self.get_object()
-            self.filter_form = self.get_form()
+            self.filter_form = forms.ChartFilterForm(data=request.GET)
             return self.render_to_response(self.get_context_data(
                 object=self.object,
                 filter_form=self.filter_form,
                 question_data=self.get_question_data(),
             ))
 
-        def get_form(self):
-            data = {k: v for k, v in self.request.GET.items()
-                    if k in forms.ChartFilterForm.base_fields}
-            return forms.ChartFilterForm(data=data or None)
-
         def get_question_data(self):
             # Do not display any data if invalid data was submitted.
-            if self.filter_form.is_bound and not self.filter_form.is_valid():
+            if not self.filter_form.is_valid():
                 return None
 
-            start_date = self.filter_form.get_value('start_date')
-            end_date = self.filter_form.get_value('end_date')
+            start_date = self.filter_form.cleaned_data.get('start_date')
+            end_date = self.filter_form.cleaned_data.get('end_date')
             pollruns = self.object.pollruns.active().order_by('conducted_on')
             if start_date:
                 pollruns = pollruns.filter(conducted_on__gte=start_date)

--- a/tracpro/static/js/poll-charts.js
+++ b/tracpro/static/js/poll-charts.js
@@ -1,8 +1,8 @@
 jQuery.fn.extend({
     chart_numeric: function() {
-        var dataType = $('#id_data_type').val();
+        var dataType = $('#id_num_display').val();
         if (["sum", "average", "response-rate"].indexOf(dataType) != -1) {
-            var label = $('#id_data_type :selected').text();
+            var label = $('#id_num_display :selected').text();
             $(this).each(function(i, item) {
                 var chart = $(item);
                 chart.closest('.poll-question').find('.data-type').text(label);
@@ -115,7 +115,7 @@ $(function() {
     }).change();
 
     /* Update numeric data display on the client side. */
-    $('#id_data_type').on('change', function() {
+    $('#id_num_display').on('change', function() {
         $('.chart-numeric').chart_numeric();
     });
 

--- a/tracpro/templates/polls/_filters.html
+++ b/tracpro/templates/polls/_filters.html
@@ -18,7 +18,7 @@
       <div class="alert alert-danger">Please fix the errors below.</div>
     {% endif %}
 
-    {% fieldset filter_form "data_type" %}
+    {% fieldset filter_form "num_display" %}
 
     {% fieldset filter_form "date_range" %}
 


### PR DESCRIPTION
Some refactors ahead of upcoming filtering changes. Notably:

* Reduce filter form complexity by always binding form
* Change `data_type` -> `num_display` because I want to use the `data_` prefix to search on DataFields as required by the upcoming ticket
* Created common `get_answers()` method for the charting code so that we have one place to apply filtering changes
* Ensure database query counts are not dependent upon the number of pollruns (closer to a constant # of queries)