### PR TITLE
Adding mean, stdev and response rate calculations

### DIFF
--- a/tracpro/polls/charts.py
+++ b/tracpro/polls/charts.py
@@ -53,7 +53,7 @@ def single_pollrun(pollrun, question, answer_filters):
 
     # Calculate the average, standard deviation,
     # and response rate for this pollrun
-    if question.question_type == Question.TYPE_NUMERIC:
+    if question.question_type != Question.TYPE_OPEN:
         summaries = answers.get_answer_summaries()
         _, answer_avg = summaries.get(pollrun.pk, (0, 0))
         responses = Response.objects.filter(answers=answers).distinct()
@@ -124,6 +124,7 @@ def multiple_pollruns(pollruns, question, answer_filters):
 
         elif question.question_type == Question.TYPE_MULTIPLE_CHOICE:
             chart_type = 'multiple-choice'
+            _ = multiple_pollruns_numeric(answers, pollruns, question)
             data = multiple_pollruns_multiple_choice(answers, pollruns, question)
 
     return chart_type, render_data(data) if data else None

--- a/tracpro/polls/charts.py
+++ b/tracpro/polls/charts.py
@@ -124,7 +124,8 @@ def multiple_pollruns(pollruns, question, answer_filters):
 
         elif question.question_type == Question.TYPE_MULTIPLE_CHOICE:
             chart_type = 'multiple-choice'
-            _ = multiple_pollruns_numeric(answers, pollruns, question)
+            # Call multiple_pollruns_numeric() in order to calculate mean, stdev and resp rate
+            multiple_pollruns_numeric(answers, pollruns, question)
             data = multiple_pollruns_multiple_choice(answers, pollruns, question)
 
     return chart_type, render_data(data) if data else None

--- a/tracpro/templates/polls/answer_calculations.html
+++ b/tracpro/templates/polls/answer_calculations.html
@@ -1,4 +1,4 @@
-{% if question.question_type == question.TYPE_NUMERIC %}
+{% if question.question_type != question.TYPE_OPEN %}
   <table class="table table-striped">
     <tbody>
       <tr class="read">


### PR DESCRIPTION
Added calculations to  to poll and poll detail for non numeric questions (everything except open-ended).
There is one flake8 issue I'm not sure how to address.
https://trello.com/c/oBDHuLAN/102-add-mean-stdev-response-rate-to-categorical-questions-in-addition-to-numeric-questions
