### PR TITLE
Release: Update Celery versions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ author = u'UNICEF'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = "1.0.3"
+release = "1.0.4"
 # The short X.Y version.
 version = "1.0"
 

--- a/docs/source/releases/changelog.rst
+++ b/docs/source/releases/changelog.rst
@@ -7,13 +7,16 @@ Tracpro's version is incremented upon each merge to master according to our
 We recommend reviewing the release notes and code diffs before upgrading
 between versions.
 
-v1.0.4 (unreleased)
--------------------
+v1.0.4 (not released)
+---------------------
 
-Code diff: https://github.com/rapidpro/tracpro/compare/v1.0.3...develop
+Code diff: https://github.com/rapidpro/tracpro/compare/v1.0.3...v1.0.4
+
+* Update versions of Celery-related packages.
+
 
 v1.0.3 (released 2015-11-30)
--------------------
+----------------------------
 
 Code diff: https://github.com/rapidpro/tracpro/compare/v1.0.2...v1.0.3
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,10 +6,10 @@ Django==1.8.6
 Pillow==3.0.0
 boto==2.38.0
 django-celery==3.1.17
-  celery==3.1.19
+  celery==3.1.20
     billiard==3.3.0.21
-    kombu==3.0.29
-      amqp==1.4.7
+    kombu==3.0.32
+      amqp==1.4.8
       anyjson==0.3.3
 django-celery-transactions==0.3.5
 django-compressor==1.5

--- a/tracpro/__init__.py
+++ b/tracpro/__init__.py
@@ -6,7 +6,7 @@ from .celery import app as celery_app  # noqa
 
 
 # NOTE: Version must be updated in docs/source/conf.py as well.
-VERSION = (1, 0, 3, "final")
+VERSION = (1, 0, 4, "final")
 
 
 def get_version(version):


### PR DESCRIPTION
We had updated some Celery packages on production in order to address a Celery bug/version incompatibilities. This "fake" release will allow us to fully test the next release. 