### PR TITLE
Email config

### DIFF
--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -8,6 +8,8 @@ import djcelery
 from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
+from .utils import *  # noqa
+
 
 djcelery.setup_loader()
 

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -43,7 +43,7 @@ DEFAULT_FROM_EMAIL = 'no-reply@caktusgroup.com'
 
 EMAIL_SUBJECT_PREFIX = '[Edutrac {}]'.format(ENVIRONMENT.title())
 
-HOSTNAME = os.environ.get('HOSTNAME')
+HOSTNAME = os.environ['DOMAIN']
 
 LOGGING['handlers']['file']['filename'] = os.path.join(WEBSERVER_ROOT, 'log', 'tracpro.log')
 

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from .base import *  # noqa
 
 
-require_env('DOMAIN', 'ENVIRONMENT')
+require_env('DOMAIN', 'ENVIRONMENT', 'SECRET_KEY')
 
 ENVIRONMENT = from_env('ENVIRONMENT').lower()
 

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -3,16 +3,17 @@ from __future__ import unicode_literals
 from .base import *  # noqa
 
 
-WEBSERVER_ROOT = '/var/www/tracpro/'
+require_env('DOMAIN', 'ENVIRONMENT')
 
-ENVIRONMENT = os.environ.get('ENVIRONMENT', '').lower()
+ENVIRONMENT = from_env('ENVIRONMENT').lower()
+
+WEBSERVER_ROOT = '/var/www/tracpro/'
 
 ADMINS = [
     ('Caktus EduTrac Team', 'edutrac-team@caktusgroup.com'),
 ]
 
-ALLOWED_HOSTS = ['.' + os.environ['DOMAIN']]
-
+ALLOWED_HOSTS = ['.' + from_env('DOMAIN')]
 
 CACHES['default']['LOCATION'] = 'localhost:6379:4'
 
@@ -29,38 +30,38 @@ COMPRESS_OFFLINE_CONTEXT = {
     'testing': False,
 }
 
-CSRF_COOKIE_DOMAIN = os.environ.get('CSRF_COOKIE_DOMAIN')
+CSRF_COOKIE_DOMAIN = from_env_or_django('CSRF_COOKIE_DOMAIN')
 
 DATABASES['default'].update({
     'NAME': 'tracpro_{}'.format(ENVIRONMENT),
     'USER': 'tracpro_{}'.format(ENVIRONMENT),
-    'HOST': os.environ.get('DB_HOST', ''),
-    'PORT': os.environ.get('DB_PORT', ''),
-    'PASSWORD': os.environ.get('DB_PASSWORD', ''),
+    'HOST': from_env('DB_HOST', ''),
+    'PORT': from_env('DB_PORT', ''),
+    'PASSWORD': from_env('DB_PASSWORD', ''),
 })
 
 DEFAULT_FROM_EMAIL = 'no-reply@caktusgroup.com'
 
 EMAIL_SUBJECT_PREFIX = '[Edutrac {}]'.format(ENVIRONMENT.title())
 
-HOSTNAME = os.environ['DOMAIN']
+HOSTNAME = from_env('DOMAIN')
 
 LOGGING['handlers']['file']['filename'] = os.path.join(WEBSERVER_ROOT, 'log', 'tracpro.log')
 
 MEDIA_ROOT = os.path.join(WEBSERVER_ROOT, 'public', 'media')
 
-SECRET_KEY = os.environ.get('SECRET_KEY', '')
+SECRET_KEY = from_env('SECRET_KEY')
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'HTTPS')
 
 SESSION_CACHE_ALIAS = "default"
 
-SESSION_COOKIE_DOMAIN = os.environ.get('SESSION_COOKIE_DOMAIN')
+SESSION_COOKIE_DOMAIN = from_env('SESSION_COOKIE_DOMAIN')
 
 SESSION_COOKIE_SECURE = False
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
-SITE_HOST_PATTERN = os.environ.get('SITE_HOST_PATTERN')
+SITE_HOST_PATTERN = from_env('SITE_HOST_PATTERN')
 
 STATIC_ROOT = os.path.join(WEBSERVER_ROOT, 'public', 'static')

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -54,8 +54,6 @@ EMAIL_USE_SSL = from_env_or_django('EMAIL_USE_SSL')
 
 EMAIL_USE_TLS = from_env_or_django('EMAIL_USE_TLS')
 
-assert not (EMAIL_USE_SSL and EMAIL_USE_TLS)  # cannot use both at once
-
 EMAIL_PORT = from_env('EMAIL_PORT', 587 if EMAIL_USE_TLS else 465 if EMAIL_USE_SSL else 25)
 
 HOSTNAME = from_env('DOMAIN')

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -40,9 +40,23 @@ DATABASES['default'].update({
     'PASSWORD': from_env('DB_PASSWORD', ''),
 })
 
-DEFAULT_FROM_EMAIL = 'no-reply@caktusgroup.com'
+DEFAULT_FROM_EMAIL = "no-reply@{}".format(from_env('DOMAIN'))
+
+EMAIL_HOST = from_env_or_django('EMAIL_HOST')
+
+EMAIL_HOST_PASSWORD = from_env_or_django('EMAIL_HOST_PASSWORD')
+
+EMAIL_HOST_USER = from_env_or_django('EMAIL_HOST_USER')
 
 EMAIL_SUBJECT_PREFIX = '[Edutrac {}]'.format(ENVIRONMENT.title())
+
+EMAIL_USE_SSL = from_env_or_django('EMAIL_USE_SSL')
+
+EMAIL_USE_TLS = from_env_or_django('EMAIL_USE_TLS')
+
+assert not (EMAIL_USE_SSL and EMAIL_USE_TLS)  # cannot use both at once
+
+EMAIL_PORT = from_env('EMAIL_PORT', 587 if EMAIL_USE_TLS else 465 if EMAIL_USE_SSL else 25)
 
 HOSTNAME = from_env('DOMAIN')
 
@@ -53,6 +67,8 @@ MEDIA_ROOT = os.path.join(WEBSERVER_ROOT, 'public', 'media')
 SECRET_KEY = from_env('SECRET_KEY')
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'HTTPS')
+
+SERVER_EMAIL = "no-reply@{}".format(from_env('DOMAIN'))
 
 SESSION_CACHE_ALIAS = "default"
 

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -64,5 +64,3 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 SITE_HOST_PATTERN = os.environ.get('SITE_HOST_PATTERN')
 
 STATIC_ROOT = os.path.join(WEBSERVER_ROOT, 'public', 'static')
-
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/tracpro/settings/utils.py
+++ b/tracpro/settings/utils.py
@@ -1,0 +1,22 @@
+import os
+
+from django.conf import global_settings as django_defaults
+from django.core.exceptions import ImproperlyConfigured
+
+
+def from_env(variable, default=None):
+    """Return the variable from the environment, falling back to a default."""
+    return os.environ.get(variable, default)
+
+
+def from_env_or_django(variable):
+    """Return the variable from the environment, falling back to the Django default."""
+    return from_env(variable, getattr(django_defaults, variable))
+
+
+def require_env(*variables):
+    """Raise ImproperlyConfigured unless the variable is in the environment."""
+    for variable in variables:
+        if variable not in os.environ:
+            raise ImproperlyConfigured(
+                "{} must be defined in the environment.".format(variable))


### PR DESCRIPTION
Grab email configuration values from the environment.

Also included:
* Utilities for environment variables
* Use Django defaults if possible
* Remove need for `HOSTNAME` environment variable (since it is a duplicate of `DOMAIN`)