### PR TITLE
Settings tweaks

### DIFF
--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -5,6 +5,8 @@ from .base import *  # noqa
 
 require_env('DOMAIN', 'ENVIRONMENT', 'SECRET_KEY')
 
+DOMAIN = from_env('DOMAIN')
+
 ENVIRONMENT = from_env('ENVIRONMENT').lower()
 
 WEBSERVER_ROOT = '/var/www/tracpro/'
@@ -13,7 +15,7 @@ ADMINS = [
     ('Caktus EduTrac Team', 'edutrac-team@caktusgroup.com'),
 ]
 
-ALLOWED_HOSTS = ['.' + from_env('DOMAIN')]
+ALLOWED_HOSTS = [".{}".format(DOMAIN)]
 
 CACHES['default']['LOCATION'] = 'localhost:6379:4'
 
@@ -30,7 +32,7 @@ COMPRESS_OFFLINE_CONTEXT = {
     'testing': False,
 }
 
-CSRF_COOKIE_DOMAIN = from_env_or_django('CSRF_COOKIE_DOMAIN')
+CSRF_COOKIE_DOMAIN = ".{}".format(DOMAIN)
 
 DATABASES['default'].update({
     'NAME': 'tracpro_{}'.format(ENVIRONMENT),
@@ -40,7 +42,7 @@ DATABASES['default'].update({
     'PASSWORD': from_env('DB_PASSWORD', ''),
 })
 
-DEFAULT_FROM_EMAIL = "no-reply@{}".format(from_env('DOMAIN'))
+DEFAULT_FROM_EMAIL = "no-reply@{}".format(DOMAIN)
 
 EMAIL_HOST = from_env_or_django('EMAIL_HOST')
 
@@ -56,7 +58,7 @@ EMAIL_USE_TLS = from_env_or_django('EMAIL_USE_TLS')
 
 EMAIL_PORT = from_env('EMAIL_PORT', 587 if EMAIL_USE_TLS else 465 if EMAIL_USE_SSL else 25)
 
-HOSTNAME = from_env('DOMAIN')
+HOSTNAME = DOMAIN
 
 LOGGING['handlers']['file']['filename'] = os.path.join(WEBSERVER_ROOT, 'log', 'tracpro.log')
 
@@ -66,11 +68,11 @@ SECRET_KEY = from_env('SECRET_KEY')
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'HTTPS')
 
-SERVER_EMAIL = "no-reply@{}".format(from_env('DOMAIN'))
+SERVER_EMAIL = "no-reply@{}".format(DOMAIN)
 
 SESSION_CACHE_ALIAS = "default"
 
-SESSION_COOKIE_DOMAIN = from_env('SESSION_COOKIE_DOMAIN')
+SESSION_COOKIE_DOMAIN = ".{}".format(DOMAIN)
 
 SESSION_COOKIE_SECURE = False
 

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -76,6 +76,4 @@ SESSION_COOKIE_SECURE = False
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
-SITE_HOST_PATTERN = from_env('SITE_HOST_PATTERN')
-
 STATIC_ROOT = os.path.join(WEBSERVER_ROOT, 'public', 'static')

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from .base import *  # noqa
 
 
-require_env('DOMAIN', 'ENVIRONMENT', 'SECRET_KEY')
+require_env('DB_NAME', 'DB_USER', 'DOMAIN', 'ENVIRONMENT', 'SECRET_KEY')
 
 DOMAIN = from_env('DOMAIN')
 
@@ -35,8 +35,8 @@ COMPRESS_OFFLINE_CONTEXT = {
 CSRF_COOKIE_DOMAIN = ".{}".format(DOMAIN)
 
 DATABASES['default'].update({
-    'NAME': 'tracpro_{}'.format(ENVIRONMENT),
-    'USER': 'tracpro_{}'.format(ENVIRONMENT),
+    'NAME': from_env('DB_NAME', ''),
+    'USER': from_env('DB_USER', ''),
     'HOST': from_env('DB_HOST', ''),
     'PORT': from_env('DB_PORT', ''),
     'PASSWORD': from_env('DB_PASSWORD', ''),


### PR DESCRIPTION
* `SITE_HOST_PATTERN` appears to be a historic setting, no longer in use in this repo, `rapidpro`, `rapidpro-python`, `dash`, or `smartmin`.
* Several other settings are based on the domain and can thus be generated.
* Require specification of `DB_NAME` and `DB_USER` from the environment.