### PR TITLE
Update logging configuration

### DIFF
--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -107,9 +107,6 @@ LOGGING = {
         'verbose': {
             'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
         },
-        'basic': {
-            'format': '%(levelname)s %(asctime)s %(message)s'
-        },
     },
     'handlers': {
         'console': {
@@ -122,36 +119,27 @@ LOGGING = {
             'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler',
         },
-        'file': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'formatter': 'basic',
-            'filename': os.path.join(PROJECT_ROOT, 'edutrac.log'),
-            'maxBytes': 10 * 1024 * 1024,  # 10 Mb
-            'backupCount': 10,
-        }
     },
     'loggers': {
         'celery': {
-            'handlers': ['file', 'mail_admins'],
+            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
         },
         'httprouterthread': {
-            'handlers': ['file'],
+            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
         },
         'django.request': {
-            'handlers': ['mail_admins'],
+            'handlers': ['console', 'mail_admins'],
             'level': 'ERROR',
             'propagate': True,
         },
         'django.db.backends': {
             'level': 'ERROR',
-            'handlers': ['mail_admins'],
-            'propagate': False,
+            'handlers': ['console', 'mail_admins'],
         },
         'tracpro': {
-            'handlers': ['file', 'mail_admins'],
+            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
         },
     },

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -122,27 +122,25 @@ LOGGING = {
     },
     'loggers': {
         'celery': {
-            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
         },
         'httprouterthread': {
-            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
         },
         'django.request': {
-            'handlers': ['console', 'mail_admins'],
             'level': 'ERROR',
             'propagate': True,
         },
         'django.db.backends': {
             'level': 'ERROR',
-            'handlers': ['console', 'mail_admins'],
         },
         'tracpro': {
-            'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
         },
     },
+    'root': {
+        'handlers': ['console', 'mail_admins'],
+    }
 }
 
 LOGIN_REDIRECT_URL = reverse_lazy('home.home')

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -60,8 +60,6 @@ EMAIL_PORT = from_env('EMAIL_PORT', 587 if EMAIL_USE_TLS else 465 if EMAIL_USE_S
 
 HOSTNAME = DOMAIN
 
-LOGGING['handlers']['file']['filename'] = os.path.join(WEBSERVER_ROOT, 'log', 'tracpro.log')
-
 MEDIA_ROOT = os.path.join(WEBSERVER_ROOT, 'public', 'media')
 
 SECRET_KEY = from_env('SECRET_KEY')

--- a/tracpro/settings/dev.py
+++ b/tracpro/settings/dev.py
@@ -15,6 +15,7 @@ SECRET_KEY = 'secret-key' * 5
 
 TEMPLATE_DEBUG = True
 
+LOGGING['root']['handlers'] = ['console']
+
 for logger in LOGGING.get('loggers', {}):
     LOGGING['loggers'][logger]['level'] = 'DEBUG'
-    LOGGING['loggers'][logger]['handlers'] = ['console']

--- a/tracpro/settings/dev.py
+++ b/tracpro/settings/dev.py
@@ -16,4 +16,5 @@ SECRET_KEY = 'secret-key' * 5
 TEMPLATE_DEBUG = True
 
 for logger in LOGGING.get('loggers', {}):
+    LOGGING['loggers'][logger]['level'] = 'DEBUG'
     LOGGING['loggers'][logger]['handlers'] = ['console']


### PR DESCRIPTION
Tweaks to the logging configuration based on our current hosted Tracpro setup.

The console is written to syslog, which we then forward to a log service.