### PR TITLE
Use unicode_literals in all files

### DIFF
--- a/tracpro/__init__.py
+++ b/tracpro/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.

--- a/tracpro/baseline/__init__.py
+++ b/tracpro/baseline/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/baseline/charts.py
+++ b/tracpro/baseline/charts.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from dateutil.relativedelta import relativedelta
 
 import numpy

--- a/tracpro/baseline/forms.py
+++ b/tracpro/baseline/forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/tracpro/baseline/models.py
+++ b/tracpro/baseline/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _

--- a/tracpro/baseline/tests/__init__.py
+++ b/tracpro/baseline/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/baseline/tests/test_charts.py
+++ b/tracpro/baseline/tests/test_charts.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 
 from dateutil.relativedelta import relativedelta

--- a/tracpro/baseline/tests/test_forms.py
+++ b/tracpro/baseline/tests/test_forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.core.exceptions import NON_FIELD_ERRORS
 
 from tracpro.test.cases import TracProDataTest

--- a/tracpro/baseline/tests/test_views.py
+++ b/tracpro/baseline/tests/test_views.py
@@ -1,10 +1,13 @@
+from __future__ import unicode_literals
+
 import datetime
 
 from django.core.urlresolvers import reverse
 
-from tracpro.test.cases import TracProDataTest
-from ..models import BaselineTerm
 from tracpro.polls.models import Answer, PollRun, Response
+from tracpro.test.cases import TracProDataTest
+
+from ..models import BaselineTerm
 
 
 class TestBaselineTermCRUDL(TracProDataTest):

--- a/tracpro/baseline/views.py
+++ b/tracpro/baseline/views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from datetime import datetime
 from dateutil import rrule
 import pytz
@@ -130,7 +132,7 @@ class BaselineTermCRUDL(SmartCRUDL):
                     question=baseline_question,
                     value=random_answer,
                     submitted_on=baseline_datetime,
-                    category=u'')
+                    category='')
 
         def form_valid(self, form):
             baseline_question = self.form.cleaned_data['baseline_question']
@@ -168,7 +170,7 @@ class BaselineTermCRUDL(SmartCRUDL):
                         question=follow_up_question,
                         value=random_answer,
                         submitted_on=follow_up_datetime,
-                        category=u'')
+                        category='')
                 loop_count += 1
 
             return redirect(self.get_success_url())

--- a/tracpro/charts/__init__.py
+++ b/tracpro/charts/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/charts/fields.py
+++ b/tracpro/charts/fields.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/tracpro/charts/filters.py
+++ b/tracpro/charts/filters.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import copy
 
 from dateutil.relativedelta import relativedelta

--- a/tracpro/charts/templatetags/__init__.py
+++ b/tracpro/charts/templatetags/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/charts/templatetags/charts.py
+++ b/tracpro/charts/templatetags/charts.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django import template
 

--- a/tracpro/charts/tests/__init__.py
+++ b/tracpro/charts/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/charts/tests/test_filters.py
+++ b/tracpro/charts/tests/test_filters.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 
 from dateutil.relativedelta import relativedelta

--- a/tracpro/contacts/__init__.py
+++ b/tracpro/contacts/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import unicode_literals
+
 default_app_config = "tracpro.contacts.apps.ContactConfig"

--- a/tracpro/contacts/apps.py
+++ b/tracpro/contacts/apps.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/tracpro/contacts/fields.py
+++ b/tracpro/contacts/fields.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _

--- a/tracpro/contacts/tests/__init__.py
+++ b/tracpro/contacts/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/contacts/tests/factories.py
+++ b/tracpro/contacts/tests/factories.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import random
 
 import factory

--- a/tracpro/contacts/tests/test_views.py
+++ b/tracpro/contacts/tests/test_views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 import json
 import pytz

--- a/tracpro/groups/__init__.py
+++ b/tracpro/groups/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/groups/context_processors.py
+++ b/tracpro/groups/context_processors.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 
 def show_subregions_toggle_form(request):

--- a/tracpro/groups/fields.py
+++ b/tracpro/groups/fields.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from mptt import forms as mptt
 
 from django.db.models import Min

--- a/tracpro/groups/forms.py
+++ b/tracpro/groups/forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/tracpro/groups/tests/__init__.py
+++ b/tracpro/groups/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/groups/tests/factories.py
+++ b/tracpro/groups/tests/factories.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import factory
 import factory.fuzzy
 

--- a/tracpro/groups/tests/test_middleware.py
+++ b/tracpro/groups/tests/test_middleware.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 

--- a/tracpro/groups/tests/test_models.py
+++ b/tracpro/groups/tests/test_models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.contrib.auth.models import User
 from django.test.utils import override_settings
 

--- a/tracpro/home/__init__.py
+++ b/tracpro/home/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/home/tests/__init__.py
+++ b/tracpro/home/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/load_env.py
+++ b/tracpro/load_env.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from os.path import dirname, join
 
 import dotenv

--- a/tracpro/msgs/forms.py
+++ b/tracpro/msgs/forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 
 from .models import InboxMessage

--- a/tracpro/msgs/tests/__init__.py
+++ b/tracpro/msgs/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/orgs_ext/__init__.py
+++ b/tracpro/orgs_ext/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/orgs_ext/apps.py
+++ b/tracpro/orgs_ext/apps.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 from django.apps import AppConfig

--- a/tracpro/orgs_ext/constants.py
+++ b/tracpro/orgs_ext/constants.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from enum import Enum
 
 

--- a/tracpro/orgs_ext/context_processors.py
+++ b/tracpro/orgs_ext/context_processors.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf import settings
 
 

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from dash.orgs.forms import OrgForm
 
 from temba_client.base import TembaAPIError

--- a/tracpro/orgs_ext/middleware.py
+++ b/tracpro/orgs_ext/middleware.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.shortcuts import render
 from django.utils import translation

--- a/tracpro/orgs_ext/signals.py
+++ b/tracpro/orgs_ext/signals.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -1,7 +1,10 @@
+from __future__ import unicode_literals
+
+import datetime
+
 from celery import signature
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
-import datetime
 
 from django.apps import apps
 from django.conf import settings

--- a/tracpro/orgs_ext/tests/__init__.py
+++ b/tracpro/orgs_ext/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/orgs_ext/tests/factories.py
+++ b/tracpro/orgs_ext/tests/factories.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import factory
 import factory.fuzzy
 

--- a/tracpro/orgs_ext/tests/test_models.py
+++ b/tracpro/orgs_ext/tests/test_models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 from django.test import TestCase

--- a/tracpro/orgs_ext/utils.py
+++ b/tracpro/orgs_ext/utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from requests import HTTPError
 
 from temba_client.base import TembaAPIError

--- a/tracpro/polls/__init__.py
+++ b/tracpro/polls/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/polls/forms.py
+++ b/tracpro/polls/forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/tracpro/polls/templatetags/__init__.py
+++ b/tracpro/polls/templatetags/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/polls/tests/__init__.py
+++ b/tracpro/polls/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/polls/tests/factories.py
+++ b/tracpro/polls/tests/factories.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 
 from dateutil.relativedelta import relativedelta

--- a/tracpro/polls/tests/test_forms.py
+++ b/tracpro/polls/tests/test_forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 
 import mock

--- a/tracpro/polls/utils.py
+++ b/tracpro/polls/utils.py
@@ -1,6 +1,8 @@
-import re
+from __future__ import unicode_literals
 
 from decimal import InvalidOperation
+import re
+
 import numpy
 import pycountry
 import stop_words

--- a/tracpro/profiles/forms.py
+++ b/tracpro/profiles/forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.contrib.auth.models import User
 from django.core.validators import MinLengthValidator

--- a/tracpro/profiles/tests/__init__.py
+++ b/tracpro/profiles/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/profiles/tests/factories.py
+++ b/tracpro/profiles/tests/factories.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import factory
 import factory.fuzzy
 

--- a/tracpro/settings/__init__.py
+++ b/tracpro/settings/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/settings/utils.py
+++ b/tracpro/settings/utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import os
 
 from django.conf import global_settings as django_defaults

--- a/tracpro/test/__init__.py
+++ b/tracpro/test/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/tracpro/test/factories.py
+++ b/tracpro/test/factories.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from tracpro.test.temba_factories import *  # noqa
 from tracpro.contacts.tests.factories import *  # noqa
 from tracpro.groups.tests.factories import *  # noqa

--- a/tracpro/test/factory_utils.py
+++ b/tracpro/test/factory_utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import uuid
 
 import factory

--- a/tracpro/test/temba_factories.py
+++ b/tracpro/test/temba_factories.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 
 import factory

--- a/tracpro/wsgi.py
+++ b/tracpro/wsgi.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import os
 
 from . import load_env


### PR DESCRIPTION
Built on the work of @emullaney in 3ea56c6 and added `from __future__ import unicode_literals` to all Python files that don't already have it. 