### PR TITLE
Release: OrgTask backoff on failure

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ author = u'UNICEF'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = "1.3.3dev"
+release = "1.3.3"
 # The short X.Y version.
 version = "1.3"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ author = u'UNICEF'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = "1.3.2"
+release = "1.3.3dev"
 # The short X.Y version.
 version = "1.3"
 

--- a/docs/source/releases/changelog.rst
+++ b/docs/source/releases/changelog.rst
@@ -7,6 +7,11 @@ Tracpro's version is incremented upon each merge to master according to our
 We recommend reviewing the release notes and code diffs before upgrading
 between versions.
 
+v1.3.3 (in development)
+-----------------------
+
+Code diff: https://github.com/rapidpro/tracpro/compare/v1.3.2...develop
+
 v1.3.2 (released 2016-03-23)
 ----------------------------
 

--- a/docs/source/releases/changelog.rst
+++ b/docs/source/releases/changelog.rst
@@ -7,10 +7,13 @@ Tracpro's version is incremented upon each merge to master according to our
 We recommend reviewing the release notes and code diffs before upgrading
 between versions.
 
-v1.3.3 (in development)
------------------------
+v1.3.3 (released 2016-03-28)
+----------------------------
 
-Code diff: https://github.com/rapidpro/tracpro/compare/v1.3.2...develop
+Code diff: https://github.com/rapidpro/tracpro/compare/v1.3.2...v1.3.3
+
+* Implement "backoff" for OrgTasks that fail
+* Ensure that cache key timeout is set properly in OrgTask
 
 v1.3.2 (released 2016-03-23)
 ----------------------------

--- a/docs/source/releases/changelog.rst
+++ b/docs/source/releases/changelog.rst
@@ -14,6 +14,7 @@ Code diff: https://github.com/rapidpro/tracpro/compare/v1.3.2...v1.3.3
 
 * Implement "backoff" for OrgTasks that fail
 * Ensure that cache key timeout is set properly in OrgTask
+* Do not use @task decorator on class-based task
 
 v1.3.2 (released 2016-03-23)
 ----------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/caktus/rapidpro-python.git@master#egg=rapidpro-python-1.0
--e git+https://github.com/caktus/dash.git@master#egg=dash
+-e git+https://github.com/caktus/dash.git@fix-contact-sync#egg=dash
 -e git+https://github.com/caktus/smartmin.git@master#egg=smartmin-1.8.1
 
 Django==1.8.11

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/caktus/rapidpro-python.git@master#egg=rapidpro-python-1.0
--e git+https://github.com/caktus/dash.git@fix-contact-sync#egg=dash
+-e git+https://github.com/caktus/dash.git@master#egg=dash
 -e git+https://github.com/caktus/smartmin.git@master#egg=smartmin-1.8.1
 
 Django==1.8.11

--- a/tracpro/__init__.py
+++ b/tracpro/__init__.py
@@ -6,7 +6,7 @@ from .celery import app as celery_app  # noqa
 
 
 # NOTE: Version must be updated in docs/source/conf.py as well.
-VERSION = (1, 3, 2, "final")
+VERSION = (1, 3, 3, "dev")
 
 
 def get_version(version):

--- a/tracpro/__init__.py
+++ b/tracpro/__init__.py
@@ -6,7 +6,7 @@ from .celery import app as celery_app  # noqa
 
 
 # NOTE: Version must be updated in docs/source/conf.py as well.
-VERSION = (1, 3, 3, "dev")
+VERSION = (1, 3, 3, "final")
 
 
 def get_version(version):

--- a/tracpro/groups/tasks.py
+++ b/tracpro/groups/tasks.py
@@ -1,13 +1,10 @@
 from __future__ import unicode_literals
 
-from djcelery_transactions import task
-
 from django.apps import apps
 
 from tracpro.orgs_ext.tasks import OrgTask
 
 
-@task
 class SyncOrgBoundaries(OrgTask):
 
     def org_task(self, org):

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -31,9 +31,9 @@ LAST_RUN_TIME = 'last_run_time:{task}:{org}'
 
 ORG_TASK_LOCK = 'org_task:{task}:{org}'
 
-LOCK_EXPIRE = (settings.ORG_TASK_TIMEOUT * 12).seconds
+LOCK_TIMEOUT = (settings.ORG_TASK_TIMEOUT * 12).seconds
 
-RUNS_EXPIRE = datetime.timedelta(days=7).seconds
+RUNS_TIMEOUT = datetime.timedelta(days=7).seconds
 
 MAX_TIME_BETWEEN_RUNS = datetime.timedelta(days=1)
 
@@ -149,24 +149,24 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
                         last_run_time, failure_count, next_run_time))
 
         # Set the current time as the last run time.
-        self.cache_set(org, LAST_RUN_TIME, value=format_iso8601(now), timeout=RUNS_EXPIRE)
+        self.cache_set(org, LAST_RUN_TIME, value=format_iso8601(now), timeout=RUNS_TIMEOUT)
 
     def fail_count_incr(self, org):
         """Increment the org's recorded failure count by 1."""
         # Set default value to 0.
-        self.cache_add(org, FAILURE_COUNT, value=0, timeout=RUNS_EXPIRE)
+        self.cache_add(org, FAILURE_COUNT, value=0, timeout=RUNS_TIMEOUT)
         return self.cache_incr(org, FAILURE_COUNT)  # Increment value by 1.
 
     def fail_count_reset(self, org):
         """Reset the org's recorded failure count to 0."""
-        self.cache_set(org, FAILURE_COUNT, value=0, timeout=RUNS_EXPIRE)
+        self.cache_set(org, FAILURE_COUNT, value=0, timeout=RUNS_TIMEOUT)
 
     def lock_acquire(self, org):
         """Set a cache key that indicates the task is currently in progress.
 
         If the key is already set (task in progress), return False.
         """
-        return self.cache_add(org, ORG_TASK_LOCK, value='true', timeout=LOCK_EXPIRE)
+        return self.cache_add(org, ORG_TASK_LOCK, value='true', timeout=LOCK_TIMEOUT)
 
     def lock_release(self, org):
         """Delete cache key that indicates that this task is in progress."""

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -139,7 +139,7 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
             last_run_time = parse_iso8601(last_run_time)
             failure_count = self.cache_get(org, FAILURE_COUNT, default=0)
             delta = settings.ORG_TASK_TIMEOUT * 2 ** failure_count
-            delta = max(delta, MAX_TIME_BETWEEN_RUNS)
+            delta = min(delta, MAX_TIME_BETWEEN_RUNS)
             if now - last_run_time < delta:
                 return last_run_time + delta
 

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -144,8 +144,9 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
                 raise ValueError(
                     "Skipping task because rate limit was exceeded. "
                     "Last run time was {}. "
+                    "Task has failed {} times recently. "
                     "Task won't be run again before {}.".format(
-                        last_run_time, next_run_time))
+                        last_run_time, failue_count,next_run_time))
 
         # Set the current time as the last run time.
         self.cache_set(org, LAST_RUN_TIME, value=format_iso8601(now), timeout=RUNS_EXPIRE)

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -179,9 +179,9 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
         org = apps.get_model('orgs', 'Org').objects.get(pk=org_pk)
         if self.lock_acquire(org):
             try:
-                next_run_time = self.check_rate_limit(org)
+                self.check_rate_limit(org)
             except ValueError as e:
-                self.log_info(org, e.message, next_run_time=next_run_time)
+                self.log_info(org, e.message)
                 return None
 
             try:

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -146,7 +146,7 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
                     "Last run time was {}. "
                     "Task has failed {} times recently. "
                     "Task won't be run again before {}.".format(
-                        last_run_time, failue_count,next_run_time))
+                        last_run_time, failure_count, next_run_time))
 
         # Set the current time as the last run time.
         self.cache_set(org, LAST_RUN_TIME, value=format_iso8601(now), timeout=RUNS_EXPIRE)

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -183,6 +183,8 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
             except ValueError as e:
                 self.log_info(org, e.message)
                 return None
+            finally:
+                self.lock_release(org)
 
             try:
                 self.log_info(org, "Starting task.")


### PR DESCRIPTION
* Implement "back off" for OrgTasks that fail
* Ensure that cache key timeout is set properly in OrgTask
* Do not use @task decorator on class-based task