### PR TITLE
Fix timeout on poll selection

### DIFF
--- a/tracpro/polls/forms.py
+++ b/tracpro/polls/forms.py
@@ -54,20 +54,10 @@ class ActivePollsForm(forms.Form):
         uuids = self.cleaned_data['polls'].values_list('flow_uuid', flat=True)
         models.Poll.objects.set_active_for_org(self.org, uuids)
 
-        # Save the associated Questions for this poll here
-        # now that these polls have been activated for the Org
-        selected_poll_names, selected_polls = [], []
-        for poll in self.cleaned_data['polls']:
-            selected_poll_names.append(poll.name)
-            selected_polls.append(models.Poll.objects.get(id=poll.id))
-
-        temba_polls = self.org.get_temba_client().get_flows(archived=False)
-        temba_polls = {p.uuid: p for p in temba_polls}
-
         # Call a celery task to update the questions and categories
         # This takes a long time, so let's schedule it to run in the background
         sync_questions_categories.delay(
-            temba_polls, selected_poll_names, selected_polls)
+            self.org, self.cleaned_data['polls'])
 
 
 class PollChartFilterForm(filters.DateRangeFilter, filters.DataFieldFilter,

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -45,17 +45,6 @@ class PollManager(models.Manager.from_queryset(PollQuerySet)):
 
         poll.save()
 
-        # Sync related Questions, and maintain question order.
-        temba_questions = temba_poll.rulesets
-        temba_questions = OrderedDict((r.uuid, r) for r in temba_poll.rulesets)
-
-        # Remove Questions that are no longer on RapidPro.
-        poll.questions.exclude(ruleset_uuid__in=temba_questions.keys()).delete()
-
-        # Create new or update existing Questions to match RapidPro data.
-        for order, temba_question in enumerate(temba_questions.values(), 1):
-            Question.objects.from_temba(poll, temba_question, order)
-
         return poll
 
     @transaction.atomic

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -63,7 +63,7 @@ class PollManager(models.Manager.from_queryset(PollQuerySet)):
         org.polls.exclude(flow_uuid__in=uuids).update(is_active=False)
 
     def sync(self, org):
-        """Update the org's Polls and Questions from RapidPro."""
+        """Update the org's Polls from RapidPro."""
         # Retrieve current Polls known to RapidPro.
         temba_polls = org.get_temba_client().get_flows(archived=False)
         temba_polls = {p.uuid: p for p in temba_polls}

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from collections import Counter, OrderedDict
+from collections import Counter
 from itertools import chain, groupby
 import json
 from operator import itemgetter

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -140,22 +140,18 @@ def sync_questions_categories(org, polls):
 
     # Save the associated Questions for this poll here
     # now that these polls have been activated for the Org
-    selected_poll_names, selected_polls = [], []
-    for poll in polls:
-        selected_poll_names.append(poll.name)
-        selected_polls.append(Poll.objects.get(id=poll.id))
+    selected_poll_names = [poll.name for poll in polls]
 
     temba_polls = org.get_temba_client().get_flows(archived=False)
     temba_polls = {p.uuid: p for p in temba_polls}
 
-    total_polls = len(selected_poll_names)
+    total_polls = len(polls)
     logger.info(
         "Retrieving Questions and Categories for %d Poll(s) that were recently updated via the interface." %
         (total_polls))
     for temba_poll in temba_polls.values():
         if temba_poll.name in selected_poll_names:
-            poll_index = selected_poll_names.index(temba_poll.name)
-            poll = selected_polls[poll_index]
+            poll = polls[selected_poll_names.index(temba_poll.name)]
             # Sync related Questions, and maintain question order.
             temba_questions = OrderedDict((r.uuid, r) for r in temba_poll.rulesets)
 

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -138,6 +138,10 @@ def sync_questions_categories(temba_polls, selected_poll_names, selected_polls):
     # Create new or update SELECTED Polls to match RapidPro data.
     from tracpro.polls.models import Question
 
+    total_polls = len(selected_poll_names)
+    logger.info(
+        "Retrieving Questions and Categories for %d Polls that were recently updated via the interface." %
+        (total_polls))
     for temba_poll in temba_polls.values():
         if temba_poll.name in selected_poll_names:
             poll_index = selected_poll_names.index(temba_poll.name)
@@ -151,3 +155,5 @@ def sync_questions_categories(temba_polls, selected_poll_names, selected_polls):
             # Create new or update existing Questions to match RapidPro data.
             for order, temba_question in enumerate(temba_questions.values(), 1):
                 Question.objects.from_temba(poll, temba_question, order)
+
+    logger.info("Completed retrieving Questions and Categories for %d Polls." % (total_polls))

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -136,7 +136,7 @@ class SyncOrgPolls(OrgTask):
 @task
 def sync_questions_categories(org, polls):
     # Create new or update SELECTED Polls to match RapidPro data.
-    from tracpro.polls.models import Poll, Question
+    from tracpro.polls.models import Question
 
     # Save the associated Questions for this poll here
     # now that these polls have been activated for the Org

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+from collections import OrderedDict
+
 from django.apps import apps
 from django.utils import timezone
 
@@ -13,7 +15,6 @@ from dash.utils import datetime_to_ms
 
 from tracpro.contacts.models import Contact
 from tracpro.orgs_ext.tasks import OrgTask
-
 
 logger = get_task_logger(__name__)
 
@@ -130,3 +131,23 @@ class SyncOrgPolls(OrgTask):
         are no longer on the remote.
         """
         apps.get_model('polls', 'Poll').objects.sync(org)
+
+
+@task
+def sync_questions_categories(temba_polls, selected_poll_names, selected_polls):
+    # Create new or update SELECTED Polls to match RapidPro data.
+    from tracpro.polls.models import Question
+
+    for temba_poll in temba_polls.values():
+        if temba_poll.name in selected_poll_names:
+            poll_index = selected_poll_names.index(temba_poll.name)
+            poll = selected_polls[poll_index]
+            # Sync related Questions, and maintain question order.
+            temba_questions = OrderedDict((r.uuid, r) for r in temba_poll.rulesets)
+
+            # Remove Questions that are no longer on RapidPro.
+            poll.questions.exclude(ruleset_uuid__in=temba_questions.keys()).delete()
+
+            # Create new or update existing Questions to match RapidPro data.
+            for order, temba_question in enumerate(temba_questions.values(), 1):
+                Question.objects.from_temba(poll, temba_question, order)

--- a/tracpro/polls/tests/test_forms.py
+++ b/tracpro/polls/tests/test_forms.py
@@ -100,4 +100,5 @@ class TestActivePollsForm(TracProTest):
         self.form.save()
 
         self.assertTrue(mock_sync_questions.delay.called)
-        mock_sync_questions.delay.assert_called_with({}, [self.poll_1.name], [self.poll_1])
+        self.assertEqual(mock_sync_questions.delay.call_args_list[0][0][0], self.org)
+        self.assertEqual(list(mock_sync_questions.delay.call_args_list[0][0][1]), [self.poll_1])

--- a/tracpro/polls/tests/test_forms.py
+++ b/tracpro/polls/tests/test_forms.py
@@ -96,7 +96,6 @@ class TestActivePollsForm(TracProTest):
         self.form = forms.ActivePollsForm(org=self.org, data=self.data)
 
         self.assertTrue(self.form.is_valid())
-        self.mock_temba_client.get_flows.return_value = []
         self.form.save()
 
         self.assertTrue(mock_sync_questions.delay.called)

--- a/tracpro/polls/tests/test_tasks.py
+++ b/tracpro/polls/tests/test_tasks.py
@@ -11,16 +11,18 @@ from ..tasks import sync_questions_categories
 
 class TestPollTask(TracProTest):
 
-    @mock.patch.object(models.Question.objects, 'from_temba')
-    def test_sync_questions_categories(self, mock_question_from_temba):
+    @mock.patch.object(models.Poll, 'get_flow_definition')
+    def test_sync_questions_categories(self, mock_poll_get_flow):
         self.org = factories.Org()
-        self.poll_1 = factories.Poll(org=self.org)
-        self.poll_2 = factories.Poll(org=self.org)
+        self.poll_1 = factories.Poll(org=self.org, name='Poll 1')
+        self.poll_2 = factories.Poll(org=self.org, name='Poll 2')
         # Create 2 questions locally:
         # one that is on RapidPro
         # and one that should be removed because it won't be on RapidPro
-        self.question_1 = factories.Question(poll=self.poll_1, ruleset_uuid='goodquestion')
-        self.question_2 = factories.Question(poll=self.poll_1, ruleset_uuid='oldquestion')
+        self.question_1 = factories.Question(
+            poll=self.poll_1, ruleset_uuid='goodquestion', question_type=models.Question.TYPE_MULTIPLE_CHOICE)
+        self.question_2 = factories.Question(
+            poll=self.poll_1, ruleset_uuid='oldquestion', question_type=models.Question.TYPE_MULTIPLE_CHOICE)
 
         # Data to pass to form for testing. Only select one poll
         self.data = [self.poll_1]
@@ -28,17 +30,27 @@ class TestPollTask(TracProTest):
         flow_1 = mock.Mock()
         flow_1.uuid = 'abcdefg123'
         flow_1.name = self.poll_1.name
-        ruleset = mock.Mock()
-        ruleset.uuid = 'goodquestion'
-        flow_1.rulesets = [ruleset]
+        ruleset_existing = mock.Mock()
+        ruleset_existing.uuid = 'goodquestion'
+        ruleset_existing.label = 'good question'
+        ruleset_new = mock.Mock()
+        ruleset_new.uuid = 'newquestion'
+        ruleset_new.label = 'new question'
+        flow_1.rulesets = [ruleset_existing, ruleset_new]
+
+        # Mock the call to the API to send back a single flow matching our first poll
         self.mock_temba_client.get_flows.return_value = [flow_1]
+        # Mock this call to return an empty rule set so that RapidPro API is not called
+        mock_poll_get_flow.return_value.rulesets = []
 
         # Assert that the 2 questions exist before we sync when one should be deleted
-        self.assertEqual(models.Question.objects.all().count(), 2)
+        self.assertEqual(models.Question.objects.count(), 2)
         with mock.patch('tracpro.polls.tasks.logger.info') as mock_logger:
             sync_questions_categories(self.org, self.data)
-            self.assertEqual(models.Question.objects.all().count(), 1)  # only one question should remain
+            # Two questions exist locallyi, one is new from the RapidPro API mock (flow_1.rulesets)
+            self.assertEqual(models.Question.objects.count(), 2)
             self.assertEqual(models.Question.objects.first().ruleset_uuid, 'goodquestion')
+            self.assertEqual(models.Question.objects.last().ruleset_uuid, 'newquestion')
             # Only 1 poll was reflected in the log message as only 1 poll was sent into the form data
             self.assertEqual(mock_logger.call_count, 2)
             self.assertIn("1 Poll(s)", mock_logger.call_args[0][0])

--- a/tracpro/polls/tests/test_tasks.py
+++ b/tracpro/polls/tests/test_tasks.py
@@ -1,0 +1,42 @@
+from __future__ import unicode_literals
+
+import mock
+
+from tracpro.test import factories
+from tracpro.test.cases import TracProTest
+
+from .. import models
+from ..tasks import sync_questions_categories
+
+
+class TestPollTask(TracProTest):
+
+    @mock.patch.object(models.Question.objects, 'from_temba')
+    def test_sync_questions_categories(self, mock_question_from_temba):
+        self.org = factories.Org()
+        self.poll_1 = factories.Poll(org=self.org)
+        self.poll_2 = factories.Poll(org=self.org)
+        # Create 2 questions locally:
+        # one that is on RapidPro
+        # and one that should be removed because it won't be on RapidPro
+        self.question_1 = factories.Question(poll=self.poll_1, ruleset_uuid='goodquestion')
+        self.question_2 = factories.Question(poll=self.poll_1, ruleset_uuid='oldquestion')
+
+        # Data to pass to form for testing. Only select one poll
+        self.data = [self.poll_1]
+        # Patch the call to the API
+        flow_1 = mock.Mock()
+        flow_1.uuid = 'abcdefg123'
+        flow_1.name = self.poll_1.name
+        ruleset = mock.Mock()
+        ruleset.uuid = 'goodquestion'
+        flow_1.rulesets = [ruleset]
+        self.mock_temba_client.get_flows.return_value = [flow_1]
+
+        with mock.patch('tracpro.polls.tasks.logger.info') as mock_logger:
+            sync_questions_categories(self.org, self.data)
+            self.assertEqual(models.Question.objects.all().count(), 1)  # only one question should remain
+            self.assertEqual(models.Question.objects.first().ruleset_uuid, 'goodquestion')
+            # Only 1 poll was reflected in the log message as only 1 poll was sent into the form data
+            self.assertEqual(mock_logger.call_count, 2)
+            self.assertIn("1 Poll(s)", mock_logger.call_args[0][0])

--- a/tracpro/polls/tests/test_tasks.py
+++ b/tracpro/polls/tests/test_tasks.py
@@ -33,6 +33,8 @@ class TestPollTask(TracProTest):
         flow_1.rulesets = [ruleset]
         self.mock_temba_client.get_flows.return_value = [flow_1]
 
+        # Assert that the 2 questions exist before we sync when one should be deleted
+        self.assertEqual(models.Question.objects.all().count(), 2)
         with mock.patch('tracpro.polls.tasks.logger.info') as mock_logger:
             sync_questions_categories(self.org, self.data)
             self.assertEqual(models.Question.objects.all().count(), 1)  # only one question should remain

--- a/tracpro/polls/tests/test_tasks.py
+++ b/tracpro/polls/tests/test_tasks.py
@@ -49,7 +49,7 @@ class TestPollTask(TracProTest):
 
         # Call the task to sync questions...
         sync_questions_categories(self.org, self.data)
-        # Two questions exist locallyi, one is new from the RapidPro API mock (flow_1.rulesets)
+        # Two questions exist locally, one is new from the RapidPro API mock (flow_1.rulesets)
         self.assertEqual(models.Question.objects.count(), 2)
         self.assertEqual(models.Question.objects.first().ruleset_uuid, 'goodquestion')
         self.assertEqual(models.Question.objects.last().ruleset_uuid, 'newquestion')

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -23,7 +23,6 @@ from tracpro.groups.models import Group, Region
 
 from . import charts, forms, maps, tasks
 from .models import Poll, Question, PollRun, Response
-from .tasks import sync_questions_categories
 
 
 class PollCRUDL(smartmin.SmartCRUDL):
@@ -195,38 +194,6 @@ class PollCRUDL(smartmin.SmartCRUDL):
         def form_valid(self, form):
             form.save()
 
-            # Save the associated Questions for this poll here
-            # now that these polls have been activated for the Org
-            selected_poll_names, selected_polls = [], []
-            for poll in form.cleaned_data['polls']:
-                selected_poll_names.append(poll.name)
-                selected_polls.append(Poll.objects.get(id=poll.id))
-
-            org = self.request.org
-            temba_polls = org.get_temba_client().get_flows(archived=False)
-            temba_polls = {p.uuid: p for p in temba_polls}
-
-            # Call a celery task to update the questions and categories
-            # This takes a long time, so let's schedule it to run in the background
-            sync_questions_categories.apply_async(
-                temba_polls, selected_poll_names, selected_polls)
-
-            """
-            # Create new or update SELECTED Polls to match RapidPro data.
-            for temba_poll in temba_polls.values():
-                if temba_poll.name in selected_poll_names:
-                    poll_index = selected_poll_names.index(temba_poll.name)
-                    poll = selected_polls[poll_index]
-                    # Sync related Questions, and maintain question order.
-                    temba_questions = OrderedDict((r.uuid, r) for r in temba_poll.rulesets)
-
-                    # Remove Questions that are no longer on RapidPro.
-                    poll.questions.exclude(ruleset_uuid__in=temba_questions.keys()).delete()
-
-                    # Create new or update existing Questions to match RapidPro data.
-                    for order, temba_question in enumerate(temba_questions.values(), 1):
-                        Question.objects.from_temba(poll, temba_question, order)
-            """
             return super(PollCRUDL.Select, self).form_valid(form)
 
 


### PR DESCRIPTION
Addresses https://caktus.atlassian.net/browse/TD-8

This is a proof of concept fix that I'd like to test out on staging.

Because the Poll sync also pulls down all question/categorical data down locally, it can time out when there are many polls for an org with a lot of questions. 

This change moves the question sync into the form save so that only active polls get questions synced.