### PR TITLE
[TD-4] Web interface to fetch past runs

### DIFF
--- a/docs/users/getting-started.rst
+++ b/docs/users/getting-started.rst
@@ -37,20 +37,13 @@ There won't be much to see until you tell TracPro about which flows and groups t
 Fetching old runs
 ------------------
 
-If a new poll is added, TracPro will only track runs made after the poll has been added. If you need to fetch older runs, then there is a management task which allows you to do this. The command takes two parameters:
+If a new poll is added, TracPro will only track runs made after the poll has been added.
+If you need to fetch older runs, then there is a button which allows you to do this.
 
-#. The database id of the organization
-#. A number of minutes, hours or days::
-
-    # fetches all runs for org #1 made in the last 45 minutes
-    $ ./manage.py fetchruns 1 --minutes=45
-
-    # fetches all runs for org #2 made in the last 6 hours
-    $ ./manage.py fetchruns 2 --hours=6
-
-    # fetches all runs for org #3 made in the last 2 days (48 hours)
-    $ ./manage.py fetchruns 3 --days=2
-
+ * Navigate to `http://SUBDOMAIN.yourtracprodomain/`.
+ * Navigate to **Administration** > **Organization** and click **Fetch runs** (on the right side near the top).
+ * Enter how many days in the past the fetch should go. For example, to fetch runs from the last two weeks, enter 14.
+ * Click **Submit**.
 
 **One should use this command with caution as it could potentially try to download a very high number of runs**
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ django-guardian==1.3.1
 django-mptt==0.8.3
 django-redis==3.8.4
   redis==2.10.5
-django-smart-selects==1.2.2
+django-smart-selects==1.2.9
 django-timezones==0.2
 enum34==1.1.2
   Markdown==2.6.6

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from dash.orgs.forms import OrgForm
+from django.core.exceptions import ValidationError
 
 from temba_client.base import TembaAPIError
 
@@ -96,3 +97,15 @@ class OrgExtForm(OrgForm):
             self.instance._visible_data_fields = self.cleaned_data.get('contact_fields')
 
         return super(OrgExtForm, self).save(*args, **kwargs)
+
+
+class FetchRunsForm(forms.Form):
+    days = forms.IntegerField(required=False)
+    hours = forms.IntegerField(required=False)
+    minutes = forms.IntegerField(required=False)
+
+    def clean(self):
+        data = self.cleaned_data
+        if not any(data.get(name, False) for name in ['days', 'hours', 'minutes']):
+            raise ValidationError(_("Specify at least one of days, hours, or minutes"))
+        return data

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -100,12 +100,4 @@ class OrgExtForm(OrgForm):
 
 
 class FetchRunsForm(forms.Form):
-    days = forms.IntegerField(required=False)
-    hours = forms.IntegerField(required=False)
-    minutes = forms.IntegerField(required=False)
-
-    def clean(self):
-        data = self.cleaned_data
-        if not any(data.get(name, False) for name in ['days', 'hours', 'minutes']):
-            raise ValidationError(_("Specify at least one of days, hours, or minutes"))
-        return data
+    days = forms.IntegerField(initial=1, min_value=1)

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from dash.orgs.forms import OrgForm
-from django.core.exceptions import ValidationError
 
 from temba_client.base import TembaAPIError
 

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -289,11 +289,13 @@ def fetch_runs(org_id, since, email=None):
         else:
             updated += 1
 
-    log(_("Created {created} new responses and updated {updated} existing responses.").format(created=created, updated=updated))
+    log(_("Created {created} new responses and updated {updated} existing responses.")
+        .format(created=created, updated=updated))
 
     if email:
         send_mail(
-            subject=_("Results from fetching runs for organization {org_name} since {time}").format(org_name=org.name, time=since.strftime('%b %d, %Y %H:%M')),
+            subject=(_("Results from fetching runs for organization {org_name} since {time}")
+                     .format(org_name=org.name, time=since.strftime('%b %d, %Y %H:%M'))),
             message="\n".join(messages) + "\n",
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[email],

--- a/tracpro/orgs_ext/tests/test_forms.py
+++ b/tracpro/orgs_ext/tests/test_forms.py
@@ -162,28 +162,28 @@ class FetchRunsFormTest(TestCase):
         # Should fail to validate
         form = FetchRunsForm(data={})
         self.assertFalse(form.is_valid())
-        self.assertIn('__all__', form.errors)
+        self.assertIn('days', form.errors)
 
     def test_all_zeroes(self):
         # Should fail to validate
-        form = FetchRunsForm(data={'days': '0', 'hours': '0', 'minutes': '0'})
+        form = FetchRunsForm(data={'days': '0'})
         self.assertFalse(form.is_valid())
-        self.assertIn('__all__', form.errors)
+        self.assertIn('days', form.errors)
 
     def test_non_numeric(self):
         # Should fail to validate
-        form = FetchRunsForm(data={'days': 'zero', 'hours': '0', 'minutes': '0'})
+        form = FetchRunsForm(data={'days': 'zero'})
         self.assertFalse(form.is_valid())
         self.assertIn('days', form.errors)
 
     def test_non_integer(self):
         # should fail to validate
-        form = FetchRunsForm(data={'days': '1.1', 'hours': '12', 'minutes': '33'})
+        form = FetchRunsForm(data={'days': '1.1'})
         self.assertFalse(form.is_valid())
         self.assertIn('days', form.errors)
 
     def test_some_numbers(self):
         # should validate, return integers
-        form = FetchRunsForm(data={'days': '1', 'hours': '12', 'minutes': '33'})
+        form = FetchRunsForm(data={'days': '1'})
         self.assertTrue(form.is_valid())
-        self.assertEqual({'days': 1, 'hours': 12, 'minutes': 33}, form.cleaned_data)
+        self.assertEqual({'days': 1}, form.cleaned_data)

--- a/tracpro/orgs_ext/tests/test_tasks.py
+++ b/tracpro/orgs_ext/tests/test_tasks.py
@@ -21,7 +21,7 @@ class FetchRunsTaskTest(TracProDataTest):
 
         # runs = client.get_runs(flows=polls_by_flow_uuids.keys(), after=since)
         client.get_runs.assert_called_with(flows=[flow_id], after=mock.ANY)
-        self.assertEqual(mock_info_logger.call_args_list[-2], (("Fetched 0 runs for org %s" % org.id,),))
+        self.assertEqual(mock_info_logger.call_args_list[-2], (("Fetched 0 runs for org %s." % org.name,),))
         mock_info_logger.assert_called_with("Created 0 new responses and updated 0 existing responses.")
         self.assertFalse(mock_error_logger.call_count)
 
@@ -39,7 +39,7 @@ class FetchRunsTaskTest(TracProDataTest):
         # runs = client.get_runs(flows=polls_by_flow_uuids.keys(), after=since)
         client.get_runs.assert_called_with(flows=[flow_id], after=mock.ANY)
         # We pretended to return 2 runs from the client:
-        self.assertEqual(mock_info_logger.call_args_list[-2], (("Fetched 2 runs for org %s" % org.id,),))
+        self.assertEqual(mock_info_logger.call_args_list[-2], (("Fetched 2 runs for org %s." % org.name,),))
         # Only one of our runs was for one of our polls
         mock_info_logger.assert_called_with("Created 1 new responses and updated 0 existing responses.")
         self.assertFalse(mock_error_logger.call_count)

--- a/tracpro/orgs_ext/tests/test_tasks.py
+++ b/tracpro/orgs_ext/tests/test_tasks.py
@@ -1,0 +1,45 @@
+import mock
+from django.utils import timezone
+from temba_client.types import Run
+from tracpro.orgs_ext.tasks import fetch_runs
+from tracpro.test.cases import TracProDataTest
+
+
+class FetchRunsTaskTest(TracProDataTest):
+    def test_bad_org(self):
+        with self.assertRaises(ValueError):
+            fetch_runs(0, timezone.now())
+
+    @mock.patch('tracpro.orgs_ext.tasks.logger.error')
+    @mock.patch('tracpro.orgs_ext.tasks.logger.info')
+    def test_no_runs(self, mock_info_logger, mock_error_logger):
+        org = self.unicef
+        client = self.mock_temba_client
+        client.get_runs.return_value = []
+        flow_id = self.poll1.flow_uuid
+        fetch_runs(org.id, timezone.now())
+
+        # runs = client.get_runs(flows=polls_by_flow_uuids.keys(), after=since)
+        client.get_runs.assert_called_with(flows=[flow_id], after=mock.ANY)
+        self.assertEqual(mock_info_logger.call_args_list[-2], (("Fetched 0 runs for org %s" % org.id,),))
+        mock_info_logger.assert_called_with("Created 0 new responses and updated 0 existing responses.")
+        self.assertFalse(mock_error_logger.call_count)
+
+    @mock.patch('tracpro.orgs_ext.tasks.logger.error')
+    @mock.patch('tracpro.orgs_ext.tasks.logger.info')
+    def test_with_runs(self, mock_info_logger, mock_error_logger):
+        org = self.unicef
+        client = self.mock_temba_client
+        flow_id = self.poll1.flow_uuid
+        run1 = Run.create(id=123, contact=self.contact1.uuid, flow=flow_id, created_on=timezone.now(), values=[])
+        run2 = Run.create(id=123, contact=self.contact1.uuid, flow='nonesuch', created_on=timezone.now(), values=[])
+        client.get_runs.return_value = [run1, run2]
+        fetch_runs(org.id, timezone.now())
+
+        # runs = client.get_runs(flows=polls_by_flow_uuids.keys(), after=since)
+        client.get_runs.assert_called_with(flows=[flow_id], after=mock.ANY)
+        # We pretended to return 2 runs from the client:
+        self.assertEqual(mock_info_logger.call_args_list[-2], (("Fetched 2 runs for org %s" % org.id,),))
+        # Only one of our runs was for one of our polls
+        mock_info_logger.assert_called_with("Created 1 new responses and updated 0 existing responses.")
+        self.assertFalse(mock_error_logger.call_count)

--- a/tracpro/orgs_ext/tests/test_views.py
+++ b/tracpro/orgs_ext/tests/test_views.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+import datetime
+from django.conf import settings
+from django.contrib.auth.models import Permission, User
 from django.core.urlresolvers import reverse
+import mock
+from django.utils import timezone
+
 from tracpro.test.cases import TracProDataTest
 
 
@@ -11,3 +17,71 @@ class TestOrgExtCRUDLHome(TracProDataTest):
         self.login(self.admin)
         response = self.url_get('unicef', reverse(self.url_name))
         self.assertEqual(response.status_code, 200)
+
+
+class FetchRunsViewTest(TracProDataTest):
+    url_name = 'orgs_ext.org_fetchruns'
+
+    def setUp(self):
+        super(FetchRunsViewTest, self).setUp()
+        self.edit_perm = Permission.objects.get(codename='org_edit')
+        self.admin.user_permissions.add(self.edit_perm)
+        self.assertTrue(self.admin.has_perm('orgs.org_edit'))
+        self.login(self.admin)
+
+    def test_get(self):
+        response = self.url_get('unicef', reverse(self.url_name))
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_without_permission(self):
+        self.admin.user_permissions.remove(self.edit_perm)
+        # Perms are cached after we've called has_perm once, so refresh
+        # our copy of self.admin so we can double-check the permission is
+        # gone again:
+        self.admin = User.objects.get(pk=self.admin.pk)
+        self.assertFalse(self.admin.has_perm('orgs.org_edit'))
+
+        response = self.url_get('unicef', reverse(self.url_name))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(settings.LOGIN_URL + "?next", response['Location'])
+
+    def test_post_no_data(self):
+        response = self.url_post(
+            'unicef',
+            reverse(self.url_name),
+            data={}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response, 'form', None, [u'Specify at least one of days, hours, or minutes'])
+
+    def test_post_bad_data(self):
+        response = self.url_post(
+            'unicef',
+            reverse(self.url_name),
+            data={
+                'hours': 'three'
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response, 'form', 'hours', [u'Enter a whole number.'])
+
+    @mock.patch('tracpro.orgs_ext.views.tasks.fetch_runs.delay')
+    def test_post_good_data(self, mock_fetchruns):
+        since = timezone.now() - datetime.timedelta(days=3)
+        response = self.url_post(
+            'unicef',
+            reverse(self.url_name),
+            data={
+                'days': '3'
+            }
+        )
+        if response.status_code != 302:
+            self.assertFalse(response.context['form'].errors)
+        self.assertEqual(response.status_code, 302)
+        mock_fetchruns.assert_called_with(self.unicef.id, mock.ANY)
+        args, kwargs = mock_fetchruns.call_args
+        since_arg = args[1]
+        self.assertEqual(
+            since.replace(hour=0, minute=0, second=0, microsecond=0),
+            since_arg.replace(hour=0, minute=0, second=0, microsecond=0),
+        )

--- a/tracpro/orgs_ext/tests/test_views.py
+++ b/tracpro/orgs_ext/tests/test_views.py
@@ -49,18 +49,18 @@ class FetchRunsViewTest(TracProDataTest):
             data={}
         )
         self.assertEqual(response.status_code, 200)
-        self.assertFormError(response, 'form', None, [u'Specify at least one of days, hours, or minutes'])
+        self.assertFormError(response, 'form', 'days', [u'This field is required.'])
 
     def test_post_bad_data(self):
         response = self.url_post(
             'unicef',
             reverse(self.url_name),
             data={
-                'hours': 'three'
+                'days': 'three'
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertFormError(response, 'form', 'hours', [u'Enter a whole number.'])
+        self.assertFormError(response, 'form', 'days', [u'Enter a whole number.'])
 
     @mock.patch('tracpro.orgs_ext.views.tasks.fetch_runs.delay')
     def test_post_good_data(self, mock_fetchruns):
@@ -75,7 +75,7 @@ class FetchRunsViewTest(TracProDataTest):
         if response.status_code != 302:
             self.assertFalse(response.context['form'].errors)
         self.assertEqual(response.status_code, 302)
-        mock_fetchruns.assert_called_with(self.unicef.id, mock.ANY)
+        mock_fetchruns.assert_called_with(self.unicef.id, mock.ANY, self.superuser.email)
         args, kwargs = mock_fetchruns.call_args
         since_arg = args[1]
         self.assertEqual(

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -78,7 +78,10 @@ class OrgExtCRUDL(OrgCRUDL):
 
     class Fetchruns(InferOrgMixin, SmartFormView):
         form_class = forms.FetchRunsForm
-        permission = 'orgs.org_edit'
+        # Hack: has_perm always returns true for a superuser.  Since this
+        # isn't a valid permission name, it'll always be false for non superuser.
+        # If there's a real way to require superuser in SmartView, I'm all ears.
+        permission = 'must be superuser'
         success_message = _("Scheduled a fetch in the background")
         title = _("Fetch past runs for my organization")
 

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -1,20 +1,24 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.contrib import messages
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from dash.orgs.views import OrgCRUDL, InferOrgMixin, OrgPermsMixin
 from dash.utils import ms_to_datetime
+from dateutil.relativedelta import relativedelta
 
 from smartmin.templatetags.smartmin import format_datetime
-from smartmin.views import SmartUpdateView
+from smartmin.views import SmartUpdateView, SmartFormView
 
 from . import constants
 from . import forms
+from . import tasks
 
 
 class OrgExtCRUDL(OrgCRUDL):
     actions = ('create', 'update', 'list', 'home', 'edit', 'chooser',
-               'choose')
+               'choose', 'fetchruns')
 
     class Create(OrgCRUDL.Create):
         form_class = forms.OrgExtForm
@@ -71,3 +75,20 @@ class OrgExtCRUDL(OrgCRUDL):
         permission = 'orgs.org_edit'
         success_url = '@orgs_ext.org_home'
         title = _("Edit My Organization")
+
+    class Fetchruns(InferOrgMixin, SmartFormView):
+        form_class = forms.FetchRunsForm
+        permission = 'orgs.org_edit'
+        success_message = _("Scheduled a fetch in the background")
+        title = _("Fetch past runs for my organization")
+
+        def form_valid(self, form):
+            org = self.get_object()
+            howfarback = relativedelta(
+                minutes=form.cleaned_data.get('minutes') or 0,
+                hours=form.cleaned_data.get('hours') or 0,
+                days=form.cleaned_data.get('days') or 0)
+            since = timezone.now() - howfarback
+            tasks.fetch_runs.delay(org.id, since)
+            messages.success(self.request, self.derive_success_message())
+            return super(SmartFormView, self).form_valid(form)

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -554,12 +554,18 @@ class Response(models.Model):
     @classmethod
     def from_run(cls, org, run, poll=None):
         """
-        Gets or creates a response from a flow run. If response is not
-        up-to-date with provided run, then it is updated. If the run doesn't
-        match with an existing poll pollrun, it's assumed to be non-regional.
+        Gets or creates a response from a flow run and returns the response.
+
+        If response is not up-to-date with provided run, then it is updated.
+
+        If the run doesn't match with an existing poll pollrun, it's assumed
+        to be non-regional.
+
+        If a new response has been created, the returned response will have
+        attribute `is_new` = True.
         """
-        response = Response.objects.filter(pollrun__poll__org=org, flow_run_id=run.id)
-        response = response.select_related('pollrun').first()
+        responses = Response.objects.filter(pollrun__poll__org=org, flow_run_id=run.id)
+        response = responses.select_related('pollrun').first()
         run_updated_on = cls.get_run_updated_on(run)
 
         # if there is an up-to-date existing response for this run, return it

--- a/tracpro/templates/orgs_ext/org_home.html
+++ b/tracpro/templates/orgs_ext/org_home.html
@@ -3,6 +3,10 @@
 {% load i18n %}
 
 {% block read-buttons %}
+  <a class="btn btn-default pull-right" href="{% url 'orgs_ext.org_fetchruns' %}">
+    <span class="glyphicon glyphicon-download"></span>
+    {% trans "Fetch runs" %}
+  </a>
   <a class="btn btn-default pull-right" href="{% url 'orgs_ext.org_edit' %}">
     <span class="glyphicon glyphicon-pencil"></span>
     {% trans "Edit" %}

--- a/tracpro/templates/orgs_ext/org_home.html
+++ b/tracpro/templates/orgs_ext/org_home.html
@@ -3,10 +3,12 @@
 {% load i18n %}
 
 {% block read-buttons %}
-  <a class="btn btn-default pull-right" href="{% url 'orgs_ext.org_fetchruns' %}">
-    <span class="glyphicon glyphicon-download"></span>
-    {% trans "Fetch runs" %}
-  </a>
+  {% if request.user.is_superuser %}
+    <a class="btn btn-default pull-right" href="{% url 'orgs_ext.org_fetchruns' %}">
+      <span class="glyphicon glyphicon-download"></span>
+      {% trans "Fetch runs" %}
+    </a>
+  {% endif %}
   <a class="btn btn-default pull-right" href="{% url 'orgs_ext.org_edit' %}">
     <span class="glyphicon glyphicon-pencil"></span>
     {% trans "Edit" %}


### PR DESCRIPTION
Added to the org page under Administration - "Fetch runs"
button goes to a form page where user can enter days,
hours, and/or minutes. The fetch is scheduled in the background
and we return to the org page, showing a message that the fetch
has been scheduled.