### PR TITLE
[TD-18] Fixes for error emails from tasks

### DIFF
--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -200,7 +200,7 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
                 elif isinstance(e, SoftTimeLimitExceeded):
                     msg = "Time limit exceeded (#{count})."
                     full_msg = self.log_error(org, msg, count=fail_count)
-                    self.send_error_email(org, full_msg)
+                    self.send_org_error_email(org, full_msg)
                     return None
                 else:
                     msg = "Unknown failure (#{count})."
@@ -217,16 +217,16 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
             self.log_info(org, msg)
             return None
 
-    def send_error_email(self, org, msg):
+    def send_org_error_email(self, org, msg):
         # FIXME: Logging is not sending us regular logging error emails.
-        self.log_debug(org, "Starting to send error email.")
+        self.log_debug(org, "Starting to send org error email.")
         send_mail(
             subject="{}{}".format(settings.EMAIL_SUBJECT_PREFIX, msg),
             message=msg,
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=dict(settings.ADMINS).values(),
-            fail_silently=True)
-        self.log_debug(org, "Finished sending error email.")
+            fail_silently=False)
+        self.log_debug(org, "Finished sending org error email.")
 
     def wrap_logger(self, level, org, msg, *args, **kwargs):
         kwargs.setdefault('org', org.name)
@@ -301,4 +301,4 @@ def fetch_runs(org_id, since, email=None):
             message="\n".join(messages) + "\n",
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[email],
-            fail_silently=True)
+            fail_silently=False)


### PR DESCRIPTION
* Turn off 'fail_silently' so we might see problems with sending
  emails in the logs, at least
* Change the name of our send_error_email method. It was overriding
  another method of the same name but different arguments from the
  parent class, so when the parent class tried to send an error email,
  it ended up in our method and didn't work.