### PR TITLE
[TD-13] Fix redirect loop on change password

### DIFF
--- a/tracpro/profiles/middleware.py
+++ b/tracpro/profiles/middleware.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
 from django.contrib import messages
 from django.core.urlresolvers import reverse
@@ -16,6 +17,15 @@ class ForcePasswordChangeMiddleware(object):
     """
     def process_view(self, request, view_func, view_args, view_kwargs):
         if request.user.is_anonymous() or not request.user.has_profile():
+            return
+
+        if not hasattr(request, 'org'):
+            raise ImproperlyConfigured(
+                "SetOrgMiddleware must come before ForcePasswordChangeMiddleware")
+
+        if not request.org:
+            # If there's no org selected, don't interfere with the process
+            # of prompting the user for an org.
             return
 
         if request.user.profile.change_password:

--- a/tracpro/profiles/tests/test_middleware.py
+++ b/tracpro/profiles/tests/test_middleware.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from tracpro.test.cases import TracProDataTest
@@ -27,3 +28,17 @@ class ForcePasswordChangeMiddlewareTest(TracProDataTest):
 
         response = self.url_get('unicef', reverse('home.home'))
         self.assertEqual(response.status_code, 200)
+
+    def test_force_change_without_org(self):
+        # A user not using an org-specific domain will get asked to choose
+        # an org, even if the change_password flag is set.
+        self.user1.profile.change_password = True
+        self.user1.profile.save()
+
+        self.login(self.user1)
+
+        response = self.url_get(None, reverse('home.home'), follow=True)
+        self.assertRedirects(
+            response,
+            'http://testserver' + reverse(settings.SITE_CHOOSER_URL_NAME),
+            fetch_redirect_response=True)

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -356,6 +356,7 @@ SITE_ALLOW_NO_ORG = (
     'profiles.admin_update',
     'profiles.admin_list',
     'set_language',
+    'orgs_ext.org_chooser',
 )
 
 SITE_API_HOST = 'rapidpro.io'


### PR DESCRIPTION
If a user has the change_password flag set, and tries to visit a
non-org URL, they should not get stuck in a redirect loop. Instead,
make them land on the "you need to pick an org" page.