### PR TITLE
Updates for deploy for 1.5.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ author = u'UNICEF'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = "1.5.1"
+release = "1.5.2"
 
 # The short X.Y version.
 version = "1.5"

--- a/docs/releases/changelog.rst
+++ b/docs/releases/changelog.rst
@@ -7,6 +7,19 @@ Tracpro's version is incremented upon each merge to master according to our
 We recommend reviewing the release notes and code diffs before upgrading
 between versions.
 
+v1.5.2 (released 2017-03-17)
+----------------------------
+
+Code diff: https://github.com/rapidpro/tracpro/compare/v1.5.2...develop
+
+* Larger, sorted multi-select drop-downs
+* Fixes for error emails from tasks
+* Permissions fix for fetch runs front-end: Admins can now use this feature, in addition to super users.
+* Fix redirect loop on change password
+* Fixes for admins:
+    - When someone is added to an org as an admin, make sure they're flagged as staff.
+    - In the users list, add a column showing whether a user is staff or not.
+
 v1.5.1 (released 2017-02-28)
 ----------------------------
 

--- a/tracpro/__init__.py
+++ b/tracpro/__init__.py
@@ -6,7 +6,7 @@ from .celery import app as celery_app  # noqa
 
 
 # NOTE: Version must be updated in docs/conf.py as well.
-VERSION = (1, 5, 2, "dev")
+VERSION = (1, 5, 2, "final")
 
 
 def get_version(version):

--- a/tracpro/__init__.py
+++ b/tracpro/__init__.py
@@ -6,7 +6,7 @@ from .celery import app as celery_app  # noqa
 
 
 # NOTE: Version must be updated in docs/conf.py as well.
-VERSION = (1, 5, 1, "final")
+VERSION = (1, 5, 2, "dev")
 
 
 def get_version(version):

--- a/tracpro/contacts/forms.py
+++ b/tracpro/contacts/forms.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django import forms
+from django.db.models.functions import Lower
 from django.utils.translation import ugettext_lazy as _
 
 from tracpro.groups.models import Group, Region
@@ -35,9 +36,10 @@ class ContactForm(forms.ModelForm):
         self.fields['name'].required = True
         self.fields['group'].required = True
 
-        self.fields['region'].queryset = self.user.get_all_regions(org)
+        regions = self.user.get_all_regions(org).order_by(Lower('name'))
+        self.fields['region'].queryset = regions
         self.fields['group'].empty_label = ""
-        self.fields['group'].queryset = Group.get_all(org).order_by('name')
+        self.fields['group'].queryset = Group.get_all(org).order_by(Lower('name'))
 
         # Add form fields to update contact's DataField values.
         self.data_field_keys = []

--- a/tracpro/groups/forms.py
+++ b/tracpro/groups/forms.py
@@ -9,7 +9,9 @@ from tracpro.client import get_client
 class ContactGroupsForm(forms.Form):
     groups = forms.MultipleChoiceField(
         choices=(), label=_("Groups"),
-        help_text=_("Contact groups to use."))
+        help_text=_("Contact groups to use."),
+        widget=forms.widgets.SelectMultiple(attrs={'size': '20'}),
+    )
 
     def __init__(self, model, org, *args, **kwargs):
         self.model = model
@@ -20,6 +22,8 @@ class ContactGroupsForm(forms.Form):
         # Retrieve Contact Group choices from RapidPro.
         choices = [(group.uuid, "%s (%d)" % (group.name, group.count))
                    for group in get_client(org).get_groups()]
+        # Sort choices by the labels, case-insensitively
+        choices.sort(key=lambda item: item[1].lower())
         self.fields['groups'].choices = choices
 
         # Set initial group values from the org.

--- a/tracpro/groups/views.py
+++ b/tracpro/groups/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Prefetch
+from django.db.models.functions import Lower
 from django.http import (
     HttpResponseBadRequest, HttpResponseRedirect, JsonResponse)
 from django.shortcuts import redirect
@@ -130,7 +131,7 @@ class RegionCRUDL(SmartCRUDL):
             return regions
 
         def get_context_data(self, **kwargs):
-            org_boundaries = Boundary.objects.by_org(self.request.org).order_by('name')
+            org_boundaries = Boundary.objects.by_org(self.request.org).order_by(Lower('name'))
             kwargs.setdefault('org_boundaries', org_boundaries)
             return super(RegionCRUDL.List, self).get_context_data(**kwargs)
 

--- a/tracpro/home/views.py
+++ b/tracpro/home/views.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from dash.orgs.views import OrgPermsMixin
+from django.db.models.functions import Lower
 
 from django.utils.translation import ugettext_lazy as _
 
@@ -22,8 +23,7 @@ class HomeView(OrgPermsMixin, SmartTemplateView):
         return request.user.is_authenticated()
 
     def get_context_data(self, **kwargs):
-        polls = Poll.objects.active().by_org(self.request.org)
-        polls = polls.order_by('name')
+        polls = Poll.objects.active().by_org(self.request.org).order_by(Lower('name'))
 
         indicators = BaselineTerm.objects.by_org(self.request.org)
         indicators = indicators.order_by('-end_date')

--- a/tracpro/orgs_ext/tasks.py
+++ b/tracpro/orgs_ext/tasks.py
@@ -200,7 +200,7 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
                 elif isinstance(e, SoftTimeLimitExceeded):
                     msg = "Time limit exceeded (#{count})."
                     full_msg = self.log_error(org, msg, count=fail_count)
-                    self.send_error_email(org, full_msg)
+                    self.send_org_error_email(org, full_msg)
                     return None
                 else:
                     msg = "Unknown failure (#{count})."
@@ -217,16 +217,16 @@ class OrgTask(WrapCacheMixin, WrapLoggerMixin, PostTransactionTask):
             self.log_info(org, msg)
             return None
 
-    def send_error_email(self, org, msg):
+    def send_org_error_email(self, org, msg):
         # FIXME: Logging is not sending us regular logging error emails.
-        self.log_debug(org, "Starting to send error email.")
+        self.log_debug(org, "Starting to send org error email.")
         send_mail(
             subject="{}{}".format(settings.EMAIL_SUBJECT_PREFIX, msg),
             message=msg,
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=dict(settings.ADMINS).values(),
-            fail_silently=True)
-        self.log_debug(org, "Finished sending error email.")
+            fail_silently=False)
+        self.log_debug(org, "Finished sending org error email.")
 
     def wrap_logger(self, level, org, msg, *args, **kwargs):
         kwargs.setdefault('org', org.name)
@@ -301,4 +301,4 @@ def fetch_runs(org_id, since, email=None):
             message="\n".join(messages) + "\n",
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[email],
-            fail_silently=True)
+            fail_silently=False)

--- a/tracpro/orgs_ext/tests/test_views.py
+++ b/tracpro/orgs_ext/tests/test_views.py
@@ -35,9 +35,15 @@ class FetchRunsViewTest(TracProDataTest):
         self.assertEqual(response.status_code, 302)
         self.assertIn(settings.LOGIN_URL + "?next", response['Location'])
 
-    def test_get_not_superuser(self):
+    def test_get_as_admin(self):
         self.client.logout()
         self.login(self.admin)
+        response = self.url_get('unicef', reverse(self.url_name))
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_not_superuser_or_admin(self):
+        self.client.logout()
+        self.login(self.user1)
         response = self.url_get('unicef', reverse(self.url_name))
         self.assertEqual(response.status_code, 302)
         self.assertIn(settings.LOGIN_URL + "?next", response['Location'])

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -16,11 +16,18 @@ from . import forms
 from . import tasks
 
 
+class MakeAdminsIntoStaffMixin(object):
+    # Make sure all admins are staff users.
+    def post_save(self, obj):
+        obj.get_org_admins().filter(is_staff=False).update(is_staff=True)
+        return super(MakeAdminsIntoStaffMixin, self).post_save(obj)
+
+
 class OrgExtCRUDL(OrgCRUDL):
     actions = ('create', 'update', 'list', 'home', 'edit', 'chooser',
                'choose', 'fetchruns')
 
-    class Create(OrgCRUDL.Create):
+    class Create(MakeAdminsIntoStaffMixin, OrgCRUDL.Create):
         form_class = forms.OrgExtForm
         fields = ('name', 'available_languages', 'language',
                   'timezone', 'subdomain', 'api_token', 'show_spoof_data',
@@ -29,7 +36,7 @@ class OrgExtCRUDL(OrgCRUDL):
     class List(OrgCRUDL.List):
         default_order = ('name',)
 
-    class Update(OrgCRUDL.Update):
+    class Update(MakeAdminsIntoStaffMixin, OrgCRUDL.Update):
         form_class = forms.OrgExtForm
         fields = ('is_active', 'name', 'available_languages', 'language',
                   'contact_fields', 'timezone', 'subdomain', 'api_token',

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -83,12 +83,9 @@ class OrgExtCRUDL(OrgCRUDL):
         success_url = '@orgs_ext.org_home'
         title = _("Edit My Organization")
 
-    class Fetchruns(InferOrgMixin, SmartFormView):
+    class Fetchruns(InferOrgMixin, OrgPermsMixin, SmartFormView):
         form_class = forms.FetchRunsForm
-        # Hack: has_perm always returns true for a superuser.  Since this
-        # isn't a valid permission name, it'll always be false for non superuser.
-        # If there's a real way to require superuser in SmartView, I'm all ears.
-        permission = 'must be superuser'
+        permission = 'orgs.org_fetch_runs'
         success_url = '@orgs_ext.org_home'
         title = _("Fetch past runs for my organization")
 

--- a/tracpro/polls/charts.py
+++ b/tracpro/polls/charts.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.core.urlresolvers import reverse
+from django.db.models.functions import Lower
 from django.utils.http import urlencode
 
 from tracpro.charts.formatters import format_series, format_x_axis
@@ -168,7 +169,8 @@ def multiple_pollruns_numeric_split(pollruns, answers, responses, question, cont
     sum_data = []
     avg_data = []
     rate_data = []
-    for region in Region.objects.filter(pk__in=data.keys()).order_by('name'):
+    regions = (Region.objects.filter(pk__in=data.keys()).order_by(Lower('name')))
+    for region in regions:
         answer_sums, answer_avgs, answer_stdevs, response_rates = data.get(region.pk)
         region_answer_sums = []
         region_answer_avgs = []

--- a/tracpro/polls/forms.py
+++ b/tracpro/polls/forms.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django import forms
+from django.db.models.functions import Lower
 from django.utils.translation import ugettext_lazy as _
 
 from dash.utils import get_month_range
@@ -36,7 +37,9 @@ class ActivePollsForm(forms.Form):
     """Set which polls should be synced with RapidPro."""
     polls = forms.ModelMultipleChoiceField(
         queryset=None, required=False, label=_("Active flows"),
-        help_text=_("Flows to track as polls."))
+        help_text=_("Flows to track as polls."),
+        widget=forms.widgets.SelectMultiple(attrs={'size': '20'}),
+    )
 
     def __init__(self, org, *args, **kwargs):
         self.org = org
@@ -46,7 +49,7 @@ class ActivePollsForm(forms.Form):
         # NOTE: This makes an in-band request to an external API.
         models.Poll.objects.sync(self.org)
 
-        polls = models.Poll.objects.by_org(self.org)
+        polls = models.Poll.objects.by_org(self.org).order_by(Lower('rapidpro_name'))
         self.fields['polls'].queryset = polls
         self.fields['polls'].initial = polls.active()
 

--- a/tracpro/profiles/forms.py
+++ b/tracpro/profiles/forms.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django import forms
 from django.contrib.auth.models import User
 from django.core.validators import MinLengthValidator
+from django.db.models.functions import Lower
 from django.utils.translation import ugettext_lazy as _
 
 from tracpro.groups.fields import ModifiedLevelTreeNodeMultipleChoiceField
@@ -41,10 +42,12 @@ class UserForm(forms.ModelForm):
         help_text=_("Whether user must change password on next login."))
     regions = ModifiedLevelTreeNodeMultipleChoiceField(
         label=_("Regions"),
-        queryset=Region.objects.all(),
+        queryset=Region.objects.order_by(Lower('name')),
         required=False,
         help_text=_("Region(s) which this user can access. User will "
-                    "automatically be granted access to sub-regions."))
+                    "automatically be granted access to sub-regions."),
+        widget=forms.widgets.SelectMultiple(attrs={'size': '20'}),
+    )
 
     class Meta:
         model = User

--- a/tracpro/profiles/middleware.py
+++ b/tracpro/profiles/middleware.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
 from django.contrib import messages
 from django.core.urlresolvers import reverse
@@ -16,6 +17,15 @@ class ForcePasswordChangeMiddleware(object):
     """
     def process_view(self, request, view_func, view_args, view_kwargs):
         if request.user.is_anonymous() or not request.user.has_profile():
+            return
+
+        if not hasattr(request, 'org'):
+            raise ImproperlyConfigured(
+                "SetOrgMiddleware must come before ForcePasswordChangeMiddleware")
+
+        if not request.org:
+            # If there's no org selected, don't interfere with the process
+            # of prompting the user for an org.
             return
 
         if request.user.profile.change_password:

--- a/tracpro/profiles/tests/test_middleware.py
+++ b/tracpro/profiles/tests/test_middleware.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from tracpro.test.cases import TracProDataTest
@@ -27,3 +28,17 @@ class ForcePasswordChangeMiddlewareTest(TracProDataTest):
 
         response = self.url_get('unicef', reverse('home.home'))
         self.assertEqual(response.status_code, 200)
+
+    def test_force_change_without_org(self):
+        # A user not using an org-specific domain will get asked to choose
+        # an org, even if the change_password flag is set.
+        self.user1.profile.change_password = True
+        self.user1.profile.save()
+
+        self.login(self.user1)
+
+        response = self.url_get(None, reverse('home.home'), follow=True)
+        self.assertRedirects(
+            response,
+            'http://testserver' + reverse(settings.SITE_CHOOSER_URL_NAME),
+            fetch_redirect_response=True)

--- a/tracpro/profiles/views.py
+++ b/tracpro/profiles/views.py
@@ -211,7 +211,7 @@ class ManageUserCRUDL(SmartCRUDL):
         form_class = UserFormWithSuperuser
 
     class List(UserFieldsMixin, SmartListView):
-        fields = ('full_name', 'email', 'orgs', 'is_superuser')
+        fields = ('full_name', 'email', 'orgs', 'is_superuser', 'is_staff')
         default_order = ('profile__full_name',)
         select_related = ('profile',)
 

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -271,6 +271,7 @@ GROUP_PERMISSIONS = {
     "Administrators": (
         'orgs.org_home',
         'orgs.org_edit',
+        'orgs.org_fetch_runs',
         'baseline.baselineterm.*',
         'contacts.contact.*',
         'groups.boundary.*',
@@ -332,7 +333,7 @@ PERMISSIONS = {
         'delete',  # can delete an object
         'list',  # can view a list of the objects
     ),
-    'orgs.org': ('create', 'update', 'list', 'edit', 'home'),
+    'orgs.org': ('create', 'update', 'list', 'edit', 'home', 'fetch_runs'),
     'baseline.baselineterm': ('create', 'read', 'update', 'delete', 'list', 'data_spoof', 'clear_spoof'),
     'contacts.contact': ('create', 'read', 'update', 'delete', 'list'),
     'groups.group': ('list', 'most_active', 'select'),

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -356,6 +356,7 @@ SITE_ALLOW_NO_ORG = (
     'profiles.admin_update',
     'profiles.admin_list',
     'set_language',
+    'orgs_ext.org_chooser',
 )
 
 SITE_API_HOST = 'rapidpro.io'


### PR DESCRIPTION
* Larger, sorted multi-select drop-downs
* Fixes for error emails from tasks
* Permissions fix for fetch runs front-end: Admins can now use this feature, in addition to super users.
* Fix redirect loop on change password
* Fixes for admins:
    -  When someone is added to an org as an admin, make sure they're flagged as staff.
    -  In the users list, add a column showing whether a user is staff or not.
