### PR TITLE
Fixes to contact syncing

### DIFF
--- a/tracpro/client.py
+++ b/tracpro/client.py
@@ -32,6 +32,24 @@ class TracProClient(TembaClient):
     def get_boundaries(self):
         return self._get_query('boundaries', {'geometry': 'true'}, Boundary)
 
+    def get_contacts_in_groups(self, group_uuids, deleted=None):
+        """
+        Get all contacts from RapidPro that are in a list of groups,
+        only including each contact once.
+
+        :param group_uuids: array of uuids and/or names
+        :param deleted: return deleted contacts only
+        :return: iterable of TembaContact objects
+
+        https://app.rapidpro.io/api/v2/contacts
+        """
+        contact_by_uuid = {}
+        for uuid in group_uuids:
+            contact_by_uuid.update(
+                {contact.uuid: contact
+                 for contact in self.get_contacts(deleted=deleted, group=uuid)})
+        return contact_by_uuid.values()
+
 
 class TracProCursorQuery(CursorQuery):
     """

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -215,13 +215,11 @@ class Contact(models.Model):
         # Use the first Temba group that matches one of the org's Regions.
         region = _get_first(Region, temba_contact.groups)
         if not region:
-            raise NoMatchingCohortsWarning(("Unable to save contact {c.uuid} ({c}) because none of "
-                                            "their cohorts ({cohorts}) match an active Panel "
-                                            "({panels}) for this org.").format(
-                c=temba_contact,
-                cohorts=get_uuids(temba_contact.groups),
-                panels=get_uuids(Region.objects.filter(org=org, is_active=True)),
-            ))
+            raise NoMatchingCohortsWarning(
+                "Unable to save contact {c.name} ({c.uuid}) because none of "
+                "their cohorts match an active Panel for this org.".format(
+                    c=temba_contact,
+                ))
 
         # Use the first Temba group that matches one of the org's Groups.
         group = _get_first(Group, temba_contact.groups)

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -18,17 +18,26 @@ from django.utils.translation import ugettext_lazy as _
 
 from dash.utils import datetime_to_ms
 
-from temba_client.v2.types import Contact as TembaContact
+from temba_client.v2.types import Contact as TembaContact, ObjectRef
 
 from tracpro.client import get_client
 from tracpro.groups.models import Region, Group
 from tracpro.orgs_ext.constants import TaskType
+from tracpro.utils import get_uuids
 
 from .tasks import push_contact_change
 from .utils import sync_pull_contacts
 
 
 logger = logging.getLogger(__name__)
+
+
+class NoMatchingCohortsError(ValueError):
+    """
+    Have Contact.kwargs_from_temba be a little more specific about failures by
+    raising this exception.
+    """
+    pass
 
 
 class ChangeType(Enum):
@@ -52,28 +61,26 @@ class ContactQuerySet(models.QuerySet):
 class ContactManager(models.Manager.from_queryset(ContactQuerySet)):
 
     def sync(self, org):
-        recent_contacts = Contact.objects.by_org(org).active()
-        recent_contacts = recent_contacts.exclude(temba_modified_on=None)
-        recent_contacts = recent_contacts.order_by('-temba_modified_on')
+        try:
+            region_uuids = set(get_uuids(Region.get_all(org)))
+            group_uuids = set(get_uuids(Group.get_all(org)))
 
-        most_recent = recent_contacts.first()
-        sync_regions = [r.uuid for r in Region.get_all(org)]
-        sync_groups = [g.uuid for g in Group.get_all(org)]
+            created, updated, deleted, failed = sync_pull_contacts(
+                org=org,
+                group_uuids=region_uuids | group_uuids
+            )
 
-        created, updated, deleted, failed = sync_pull_contacts(
-            org=org, contact_class=Contact, fields=(), delete_blocked=True,
-            groups=sync_regions + sync_groups,
-            last_time=most_recent.temba_modified_on if most_recent else None)
-
-        org.set_task_result(TaskType.sync_contacts, {
-            'time': datetime_to_ms(timezone.now()),
-            'counts': {
-                'created': len(created),
-                'updated': len(updated),
-                'deleted': len(deleted),
-                'failed': len(failed),
-            },
-        })
+            org.set_task_result(TaskType.sync_contacts, {
+                'time': datetime_to_ms(timezone.now()),
+                'counts': {
+                    'created': len(created),
+                    'updated': len(updated),
+                    'deleted': len(deleted),
+                    'failed': len(failed),
+                },
+            })
+        except:
+            logger.exception("EXCEPTION in ContactManager.sync")
 
 
 @python_2_unicode_compatible
@@ -143,15 +150,25 @@ class Contact(models.Model):
         """Return a Temba object representing this Contact."""
         fields = {f.field.key: f.get_value() for f in self.contactfield_set.all()}
 
-        temba_contact = TembaContact()
-        temba_contact.name = self.name
-        temba_contact.urns = [self.urn]
-        temba_contact.fields = fields
-        temba_contact.groups = list(self.groups.values_list('uuid', flat=True))
-        temba_contact.language = self.language
-        temba_contact.uuid = self.uuid
+        # Include all the groups associated with the contact.
+        # In Temba v2, we get back ObjectRefs for these, so imitate that here.
+        groups = [ObjectRef.create(uuid=group.uuid, name=group.name)
+                  for group in self.groups.all()]
+        if self.region and self.region.uuid not in get_uuids(groups):
+            groups.append(ObjectRef.create(uuid=self.region.uuid, name=self.region.name))
+        if self.group and self.group.uuid not in get_uuids(groups):
+            groups.append(ObjectRef.create(uuid=self.group.uuid, name=self.group.name))
 
-        return temba_contact
+        return TembaContact.create(
+            name=self.name,
+            urns=[self.urn],
+            fields=fields,
+            groups=groups,
+            language=self.language,
+            uuid=self.uuid,
+            blocked=not self.is_active,
+            modified_on=self.modified_on
+        )
 
     def delete(self):
         """Deactivate the local copy & delete from RapidPro."""
@@ -191,19 +208,20 @@ class Contact(models.Model):
     def kwargs_from_temba(cls, org, temba_contact):
         """Get data to create a Contact instance from a Temba object."""
         def _get_first(model_class, temba_objects):
-            """Return first obj from this org that matches one of the given uuids."""
+            """Return first obj from this org that matches one of the given uuids, or None."""
             queryset = model_class.get_all(org)
-            tracpro_uuids = queryset.values_list('uuid', flat=True)
-            temba_uuids = [temba_object.uuid for temba_object in temba_objects]
-            uuid = next((uuid for uuid in temba_uuids if uuid in tracpro_uuids), None)
-            return queryset.get(uuid=uuid) if uuid else None
+            temba_uuids = get_uuids(temba_objects)
+            return queryset.filter(uuid__in=temba_uuids).first()
         # Use the first Temba group that matches one of the org's Regions.
         region = _get_first(Region, temba_contact.groups)
         if not region:
-            raise ValueError(
-                "Unable to save contact {c.uuid} ({c.name}) because none of "
-                "their cohorts match an active Panel for this org.".format(
-                    c=temba_contact))
+            raise NoMatchingCohortsError(("Unable to save contact {c.uuid} ({c}) because none of "
+                                          "their cohorts ({cohorts}) match an active Panel "
+                                          "({panels}) for this org.").format(
+                c=temba_contact,
+                cohorts=get_uuids(temba_contact.groups),
+                panels=get_uuids(Region.objects.filter(org=org, is_active=True)),
+            ))
 
         # Use the first Temba group that matches one of the org's Groups.
         group = _get_first(Group, temba_contact.groups)
@@ -219,7 +237,8 @@ class Contact(models.Model):
             '_data_field_values': temba_contact.fields,  # managed by post-save signal
         }
         if cls.objects.filter(org=org, uuid=temba_contact.uuid).exists():
-            kwargs['groups'] = list(Group.objects.filter(uuid__in=temba_contact.groups))
+            # Note that 'groups' is only a valid kwarg if the contact already exists
+            kwargs['groups'] = list(Group.objects.filter(uuid__in=get_uuids(temba_contact.groups)))
         return kwargs
 
     def push(self, change_type):

--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -32,9 +32,9 @@ from .utils import sync_pull_contacts
 logger = logging.getLogger(__name__)
 
 
-class NoMatchingCohortsError(ValueError):
+class NoMatchingCohortsWarning(Exception):
     """
-    Have Contact.kwargs_from_temba be a little more specific about failures by
+    Have Contact.kwargs_from_temba be a little more specific about this case by
     raising this exception.
     """
     pass
@@ -215,9 +215,9 @@ class Contact(models.Model):
         # Use the first Temba group that matches one of the org's Regions.
         region = _get_first(Region, temba_contact.groups)
         if not region:
-            raise NoMatchingCohortsError(("Unable to save contact {c.uuid} ({c}) because none of "
-                                          "their cohorts ({cohorts}) match an active Panel "
-                                          "({panels}) for this org.").format(
+            raise NoMatchingCohortsWarning(("Unable to save contact {c.uuid} ({c}) because none of "
+                                            "their cohorts ({cohorts}) match an active Panel "
+                                            "({panels}) for this org.").format(
                 c=temba_contact,
                 cohorts=get_uuids(temba_contact.groups),
                 panels=get_uuids(Region.objects.filter(org=org, is_active=True)),

--- a/tracpro/contacts/tests/factories.py
+++ b/tracpro/contacts/tests/factories.py
@@ -32,6 +32,8 @@ class Contact(factory_utils.SmartModelFactory):
         if create and extracted:
             # A list of groups were passed in, use them
             self.groups.add(*extracted)
+        if self.group and not self.groups.all():
+            self.groups.add(self.group)
 
 
 class TwitterContact(Contact):

--- a/tracpro/contacts/tests/test_models.py
+++ b/tracpro/contacts/tests/test_models.py
@@ -18,6 +18,7 @@ from tracpro.contacts.models import ChangeType
 from tracpro.polls.models import Response
 from tracpro.test import factories
 from tracpro.test.cases import TracProDataTest, TracProTest
+from tracpro.utils import get_uuids
 
 from .. import models
 
@@ -134,7 +135,7 @@ class ContactTest(TracProDataTest):
         self.assertEqual(temba_contact.name, "Ann")
         self.assertEqual(temba_contact.urns, ['tel:1234'])
         self.assertEqual(temba_contact.fields, {})
-        self.assertEqual(set(temba_contact.groups), set(['G-005', 'G-001']))
+        self.assertEqual(set(get_uuids(temba_contact.groups)), set(['G-005', 'G-001', self.region1.uuid]))
         self.assertEqual(temba_contact.uuid, 'C-001')
 
     def test_by_org(self):

--- a/tracpro/contacts/tests/test_utils.py
+++ b/tracpro/contacts/tests/test_utils.py
@@ -1,11 +1,15 @@
 from __future__ import unicode_literals
 
+from django.db.models import Q
 from django.utils import timezone
 
 from temba_client.v2.types import Contact as TembaContact
 
-from tracpro.test.cases import TracProTest
-from ..utils import intersection, union, filter_dict, temba_compare_contacts, temba_merge_contacts
+from tracpro.test.cases import TracProTest, TracProDataTest
+from tracpro.utils import get_uuids
+from ..models import Contact
+from ..utils import intersection, union, filter_dict, temba_compare_contacts, temba_merge_contacts, \
+    sync_pull_contacts
 
 
 class InitTest(TracProTest):
@@ -100,3 +104,109 @@ class SyncTest(TracProTest):
         self.assertEqual(sorted(merged.urns), ['email:bob@bob.com', 'tel:123', 'twitter:bob'])
         self.assertEqual(merged.fields, dict(chat_name="bob", age=23, state='IN'))
         self.assertEqual(sorted(merged.groups), ['000-001', '000-009', '000-010', '000-011'])
+
+
+class SyncPullTest(TracProDataTest):
+    def setUp(self):
+        super(SyncPullTest, self).setUp()
+
+        self.org = self.unicef
+        self.sync_regions = [self.region1, self.region2]
+        self.sync_groups = [self.group1, self.group2]
+        self.rapidpro_contacts_as_temba = [
+            tracpro_contact.as_temba()
+            for tracpro_contact in Contact.objects.filter(
+                Q(groups__in=self.sync_groups),
+                org=self.org,
+            ).distinct()
+        ]
+        self.deleted_rapidpro_contacts = []
+
+        def mock_get_contacts_in_groups(groups, deleted=None):
+            if deleted:
+                return self.deleted_rapidpro_contacts
+            else:
+                return self.rapidpro_contacts_as_temba
+
+        self.mock_temba_client.get_contacts_in_groups = mock_get_contacts_in_groups
+
+    def get_group_uuids(self):
+        return set(get_uuids(self.sync_regions) + get_uuids(self.sync_groups))
+
+    def test_no_change(self):
+        created, updated, deleted, failed = sync_pull_contacts(
+            org=self.org,
+            group_uuids=self.get_group_uuids(),
+        )
+
+        # Should be no change since we just returned the contacts we already had
+        self.assertTupleEqual(([], [], [], []), (created, updated, deleted, failed))
+
+    def test_new_contact_in_rapidpro(self):
+        original_kwargs = self.contact1.as_temba().serialize()
+        new_temba_contact = self.contact1.as_temba()
+
+        # Work around the overloaded 'delete' method on Contact to really delete contact1 locally,
+        # so as far as our code is concerned, contact1 will be a new contact when we
+        # see it come back from Rapidpro.
+        Contact.objects.filter(uuid=self.contact1.uuid).delete()
+
+        created, updated, deleted, failed = sync_pull_contacts(
+            org=self.org,
+            group_uuids=self.get_group_uuids(),
+        )
+        self.assertTupleEqual(([new_temba_contact.uuid], [], [], []), (created, updated, deleted, failed))
+
+        # We have created a new contact:
+        c = Contact.objects.get(uuid=new_temba_contact.uuid)
+        # and it has the expected data:
+        new_kwargs = c.as_temba().serialize()
+        del original_kwargs['modified_on']
+        del new_kwargs['modified_on']
+        self.assertDictEqual(original_kwargs, new_kwargs)
+
+    def test_modified_contact_in_rapidpro(self):
+        # Have "rapidpro" return a new name on the first contact in the list
+        new_name = "Mr. McGillicuddy"
+        modified = self.rapidpro_contacts_as_temba[0]
+        modified.name = new_name
+
+        existing_contact = Contact.objects.get(uuid=modified.uuid)
+
+        # Sync and see what happens
+        created, updated, deleted, failed = sync_pull_contacts(
+            org=self.org,
+            group_uuids=self.get_group_uuids(),
+        )
+        self.assertTupleEqual(([], [self.rapidpro_contacts_as_temba[0].uuid], [], []),
+                              (created, updated, deleted, failed))
+        # Our contact has changed its name, in the existing record
+        c = Contact.objects.get(uuid=self.rapidpro_contacts_as_temba[0].uuid)
+        self.assertEqual(c.pk, existing_contact.pk)
+        self.assertEqual(c.name, new_name)
+
+    def test_deleted_contact_in_rapidpro(self):
+        deleted_rapidpro_contact = self.rapidpro_contacts_as_temba.pop()
+        self.deleted_rapidpro_contacts.append(deleted_rapidpro_contact)
+        created, updated, deleted, failed = sync_pull_contacts(
+            org=self.org,
+            group_uuids=self.get_group_uuids(),
+        )
+        self.assertTupleEqual(([], [], [deleted_rapidpro_contact.uuid], []),
+                              (created, updated, deleted, failed))
+        # Our contact has changed to is_active=False
+        c = Contact.objects.get(uuid=deleted_rapidpro_contact.uuid)
+        self.assertFalse(c.is_active)
+
+    def test_blocked_contact_in_rapidpro(self):
+        blocked_contact = self.rapidpro_contacts_as_temba[0]
+        blocked_contact.blocked = True
+        created, updated, deleted, failed = sync_pull_contacts(
+            org=self.org,
+            group_uuids=self.get_group_uuids(),
+        )
+        self.assertTupleEqual(([], [], [blocked_contact.uuid], []),
+                              (created, updated, deleted, failed))
+        # Our contact has changed to is_active=False
+        c = Contact.objects.get(uuid=blocked_contact.uuid)
+        self.assertFalse(c.is_active)

--- a/tracpro/contacts/utils.py
+++ b/tracpro/contacts/utils.py
@@ -9,35 +9,29 @@ from temba_client.clients import TembaBadRequestError
 from temba_client.v2.types import Contact as TembaContact
 
 from tracpro.client import get_client
+from tracpro.utils import get_uuids
 
 
 logger = get_task_logger(__name__)
 
 
-def sync_pull_contacts(org, contact_class, fields=None, groups=None,
-                       last_time=None, delete_blocked=False):
+def sync_pull_contacts(org, group_uuids):
     """
-    Pulls updated contacts or all contacts from RapidPro and syncs with local contacts.
-    Contact class must define a class method called kwargs_from_temba which generates
-    field kwargs from a fetched temba contact.
+    Pull contacts from RapidPro and sync with local contacts.
+
     :param org: the org
-    :param contact_class: the contact class type
-    :param fields: the contact field keys used - used to determine if local contact differs
-    :param groups: the contact group UUIDs used - used to determine if local contact differs
-    :param last_time: the last time we pulled contacts, if None, sync all contacts
-    :param delete_blocked: if True, delete the blocked contacts
+    :param group_uuidss: the contact group UUIDs used - used to determine if local contact differs
     :return: tuple containing list of UUIDs for created, updated, deleted and failed contacts
     """
-    # get all remote contacts
-    client = get_client(org)
-    updated_incoming_contacts = []
-    if last_time:
-        updated_incoming_contacts = client.get_contacts(after=last_time)
-    else:
-        updated_incoming_contacts = client.get_contacts()
+    from tracpro.contacts.models import Contact, NoMatchingCohortsError
+    from tracpro.groups.models import Group
 
-    # get all existing contacts and organize by their UUID
-    existing_contacts = contact_class.objects.filter(org=org)
+    # get all remote contacts for the specified groups
+    client = get_client(org)
+    incoming_contacts = client.get_contacts_in_groups(group_uuids)
+
+    # get all existing local contacts (active or not) and organize by their UUID
+    existing_contacts = Contact.objects.filter(org=org)
     existing_by_uuid = {contact.uuid: contact for contact in existing_contacts}
 
     created_uuids = []
@@ -45,21 +39,24 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None,
     deleted_uuids = []
     failed_uuids = []
 
-    for updated_incoming in updated_incoming_contacts:
-        # delete blocked contacts if deleted_blocked=True
-        if updated_incoming.blocked and delete_blocked:
-            deleted_uuids.append(updated_incoming.uuid)
+    groups = Group.objects.filter(uuid__in=group_uuids)
 
-        elif updated_incoming.uuid in existing_by_uuid:
-            existing = existing_by_uuid[updated_incoming.uuid]
+    for temba_contact in incoming_contacts:
+        if temba_contact.blocked:
+            deleted_uuids.append(temba_contact.uuid)
 
-            diff = temba_compare_contacts(updated_incoming, existing.as_temba(), fields, groups)
+        elif temba_contact.uuid in existing_by_uuid:
+            existing = existing_by_uuid[temba_contact.uuid]
+
+            diff = temba_compare_contacts(temba_contact, existing.as_temba(), fields=(), groups=groups)
 
             if diff or not existing.is_active:
                 try:
-                    kwargs = contact_class.kwargs_from_temba(org, updated_incoming)
-                except ValueError:
-                    failed_uuids.append(updated_incoming.uuid)
+                    kwargs = Contact.kwargs_from_temba(org, temba_contact)
+                except NoMatchingCohortsError:
+                    # Should not happen since we only fetched contacts for the org's groups
+                    logger.exception("Updating existing contact")
+                    failed_uuids.append(temba_contact.uuid)
                     continue
 
                 for field, value in six.iteritems(kwargs):
@@ -68,27 +65,28 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None,
                 existing.is_active = True
                 existing.save()
 
-                updated_uuids.append(updated_incoming.uuid)
+                updated_uuids.append(temba_contact.uuid)
         else:
             try:
-                kwargs = contact_class.kwargs_from_temba(org, updated_incoming)
-            except ValueError:
-                failed_uuids.append(updated_incoming.uuid)
+                kwargs = Contact.kwargs_from_temba(org, temba_contact)
+            except NoMatchingCohortsError:
+                # Should not happen since we only fetched contacts for the org's groups
+                logger.exception("Creating contact")
+                failed_uuids.append(temba_contact.uuid)
                 continue
 
-            contact_class.objects.create(**kwargs)
+            new_contact = Contact.objects.create(**kwargs)
+            # Now set groups, we couldn't include them on creation
+            new_contact.groups = Group.objects.filter(uuid__in=get_uuids(temba_contact.groups))
             created_uuids.append(kwargs['uuid'])
 
     # any contact that has been deleted from rapidpro
-    # should also be deleted from dash
-    # if last_time was passed in, just get contacts deleted after the last time we synced
-    if last_time:
-        deleted_incoming_contacts = client.get_contacts(deleted=True, after=last_time)
-    else:
-        deleted_incoming_contacts = client.get_contacts(deleted=True)
-    for deleted_incoming in deleted_incoming_contacts:
-        deleted_uuids.append(deleted_incoming.uuid)
-    existing_contacts.filter(uuid__in=deleted_uuids).update(is_active=False)
+    # should be marked inactive in tracpro
+    deleted_rapidpro_contacts = client.get_contacts_in_groups(group_uuids, deleted=True)
+    deleted_uuids += get_uuids(deleted_rapidpro_contacts)
+
+    # Mark all deleted contacts as not active if they aren't already.
+    existing_contacts.filter(uuid__in=deleted_uuids, is_active=True).update(is_active=False)
 
     return created_uuids, updated_uuids, deleted_uuids, failed_uuids
 
@@ -104,7 +102,8 @@ def temba_compare_contacts(first, second, fields=None, groups=None):
     groups: if this is passed in, we can check that the two contacts
             belong to the same groups
 
-    Returns first difference found.
+    Returns name of first difference found, one of 'name' or 'urns' or
+    'groups' or 'fields', or None if no differences were spotted.
     """
     if first.uuid != second.uuid:  # pragma: no cover
         raise ValueError("Can't compare contacts with different UUIDs")

--- a/tracpro/contacts/utils.py
+++ b/tracpro/contacts/utils.py
@@ -23,7 +23,7 @@ def sync_pull_contacts(org, group_uuids):
     :param group_uuidss: the contact group UUIDs used - used to determine if local contact differs
     :return: tuple containing list of UUIDs for created, updated, deleted and failed contacts
     """
-    from tracpro.contacts.models import Contact, NoMatchingCohortsError
+    from tracpro.contacts.models import Contact, NoMatchingCohortsWarning
     from tracpro.groups.models import Group
 
     # get all remote contacts for the specified groups
@@ -53,9 +53,8 @@ def sync_pull_contacts(org, group_uuids):
             if diff or not existing.is_active:
                 try:
                     kwargs = Contact.kwargs_from_temba(org, temba_contact)
-                except NoMatchingCohortsError:
-                    # Should not happen since we only fetched contacts for the org's groups
-                    logger.exception("Updating existing contact")
+                except NoMatchingCohortsWarning:
+                    logger.warning("Updating existing contact", exc_info=1)
                     failed_uuids.append(temba_contact.uuid)
                     continue
 
@@ -69,9 +68,8 @@ def sync_pull_contacts(org, group_uuids):
         else:
             try:
                 kwargs = Contact.kwargs_from_temba(org, temba_contact)
-            except NoMatchingCohortsError:
-                # Should not happen since we only fetched contacts for the org's groups
-                logger.exception("Creating contact")
+            except NoMatchingCohortsWarning:
+                logger.warning("Creating contact", exc_info=1)
                 failed_uuids.append(temba_contact.uuid)
                 continue
 

--- a/tracpro/contacts/utils.py
+++ b/tracpro/contacts/utils.py
@@ -53,8 +53,8 @@ def sync_pull_contacts(org, group_uuids):
             if diff or not existing.is_active:
                 try:
                     kwargs = Contact.kwargs_from_temba(org, temba_contact)
-                except NoMatchingCohortsWarning:
-                    logger.warning("Updating existing contact", exc_info=1)
+                except NoMatchingCohortsWarning as e:
+                    logger.warning(e.message)
                     failed_uuids.append(temba_contact.uuid)
                     continue
 
@@ -68,8 +68,8 @@ def sync_pull_contacts(org, group_uuids):
         else:
             try:
                 kwargs = Contact.kwargs_from_temba(org, temba_contact)
-            except NoMatchingCohortsWarning:
-                logger.warning("Creating contact", exc_info=1)
+            except NoMatchingCohortsWarning as e:
+                logger.warning(e.message)
                 failed_uuids.append(temba_contact.uuid)
                 continue
 

--- a/tracpro/groups/models.py
+++ b/tracpro/groups/models.py
@@ -112,7 +112,13 @@ class AbstractGroup(models.Model):
 
 
 class Region(mptt.MPTTModel, AbstractGroup):
-    """A geographical region modelled as a group."""
+    """
+    *In the user interface, this is now named a "Panel"*
+
+    A geographical region modelled as a group.
+
+    In RapidPro, this is a Group.
+    """
     users = models.ManyToManyField(
         settings.AUTH_USER_MODEL, verbose_name=_("Users"), related_name='regions',
         help_text=_("Users who can access this panel"))
@@ -157,7 +163,11 @@ class Region(mptt.MPTTModel, AbstractGroup):
 
 
 class Group(AbstractGroup):
-    """A data reporting group."""
+    """
+    A data "reporting group".
+
+    In RapidPro, this is a Group.
+    """
     class Meta:
         verbose_name = 'cohort'
 

--- a/tracpro/groups/tests/test_models.py
+++ b/tracpro/groups/tests/test_models.py
@@ -42,7 +42,7 @@ class TestRegion(TracProTest):
             org=self.org, uuid='5', name="inactive", parent=self.kampala,
             is_active=False)
 
-        self.mock_temba_client.get_contacts.return_value = []
+        self.mock_temba_client.get_contacts_in_groups.return_value = []
 
     def refresh_regions(self):
         """Refresh all regions from the database."""
@@ -118,7 +118,7 @@ class TestRegion(TracProTest):
             self.makerere,
         ]))
         self.assertEqual(self.mock_temba_client.get_groups.call_count, 1)
-        self.assertEqual(self.mock_temba_client.get_contacts.call_count, 2)
+        self.assertEqual(self.mock_temba_client.get_contacts_in_groups.call_count, 2)
 
     def test_sync_update_existing(self):
         """Update existing group with new information from remote."""
@@ -137,7 +137,7 @@ class TestRegion(TracProTest):
         self.assertEqual(self.kampala.name, "Changed")
         self.assertEqual(self.kampala.parent, self.uganda)
         self.assertEqual(self.mock_temba_client.get_groups.call_count, 1)
-        self.assertEqual(self.mock_temba_client.get_contacts.call_count, 2)
+        self.assertEqual(self.mock_temba_client.get_contacts_in_groups.call_count, 2)
 
     def test_sync_reactivate(self):
         """Reactivate a group that existed previously."""
@@ -157,7 +157,7 @@ class TestRegion(TracProTest):
         self.assertEqual(self.entebbe.name, "Entebbe")
         self.assertEqual(self.entebbe.parent, None)
         self.assertEqual(self.mock_temba_client.get_groups.call_count, 1)
-        self.assertEqual(self.mock_temba_client.get_contacts.call_count, 2)
+        self.assertEqual(self.mock_temba_client.get_contacts_in_groups.call_count, 2)
 
     def test_sync_create_new(self):
         """Create a new group if the UUID hasn't been seen before."""
@@ -178,7 +178,7 @@ class TestRegion(TracProTest):
         self.assertEqual(new_region.name, "New")
         self.assertIsNone(new_region.parent, None)
         self.assertEqual(self.mock_temba_client.get_groups.call_count, 1)
-        self.assertEqual(self.mock_temba_client.get_contacts.call_count, 2)
+        self.assertEqual(self.mock_temba_client.get_contacts_in_groups.call_count, 2)
 
     def test_sync_removed_remote(self):
         """Deactivate a group locally if it has been removed from the remote."""
@@ -196,7 +196,7 @@ class TestRegion(TracProTest):
             self.makerere,
         ]))
         self.assertEqual(self.mock_temba_client.get_groups.call_count, 1)
-        self.assertEqual(self.mock_temba_client.get_contacts.call_count, 2)
+        self.assertEqual(self.mock_temba_client.get_contacts_in_groups.call_count, 2)
 
 
 class TestGroup(TracProDataTest):

--- a/tracpro/settings/dev.py
+++ b/tracpro/settings/dev.py
@@ -21,3 +21,6 @@ LOGGING['root']['handlers'] = ['console']
 
 for logger in LOGGING.get('loggers', {}):
     LOGGING['loggers'][logger]['level'] = 'DEBUG'
+
+# Don't stop tasks from running frequently
+ORG_TASK_TIMEOUT = datetime.timedelta(seconds=1)

--- a/tracpro/test/cases.py
+++ b/tracpro/test/cases.py
@@ -125,7 +125,7 @@ class TracProDataTest(TracProTest):
         self.group5 = factories.Group(org=self.unicef, name="Kandahar", uuid='G-001')
 
         # some contacts
-        self.contact1 = factories.Contact.create(
+        self.contact1 = factories.Contact(
             org=self.unicef, name="Ann", urn='tel:1234', uuid='C-001',
             region=self.region1, group=self.group1, groups=(self.group1, self.group5))
         self.contact2 = factories.Contact(

--- a/tracpro/utils.py
+++ b/tracpro/utils.py
@@ -1,0 +1,7 @@
+def get_uuids(things):
+    """
+    Return an iterable of the 'uuid' attribute values of the things.
+
+    The things can be anything with a 'uuid' attribute.
+    """
+    return [thing.uuid for thing in things]


### PR DESCRIPTION
* Get all rapidpro contacts for the selected groups,
  rather than just ones modified more recently than
  some time. This should make sure we get all the
  relevant contacts.

* Add new SyncPullTest testcase, which is intended
  to check out all the different cases in which
  something has changed on RapidPro and we then
  sync contacts.

Also, simplify the code in some places, e.g.
remove a bunch of parameters from sync_pull_contacts
that we were always passing in the same value for
anyway.