### PR TITLE
Add Google Analytics support

### DIFF
--- a/tracpro/orgs_ext/context_processors.py
+++ b/tracpro/orgs_ext/context_processors.py
@@ -23,3 +23,17 @@ def available_languages(request):
         'all_languages': all_languages,
         'show_languages': show_languages
     }
+
+
+def google_analytics(request):
+    """
+    If the org has a Google Analytics tracking code, include
+    it in the context as 'google_analytics'
+    """
+    if request.org:
+        ga = request.org.get_config('google_analytics', False)
+        if ga:
+            return {
+                'google_analytics': ga
+            }
+    return {}

--- a/tracpro/orgs_ext/tests/factories.py
+++ b/tracpro/orgs_ext/tests/factories.py
@@ -23,3 +23,8 @@ class Org(SmartModelFactory):
         self.available_languages = extracted or ["en"]
         if create:
             self.save()
+
+    @factory.post_generation
+    def google_analytics(self, create, extracted, **kwargs):
+        if extracted:
+            self.set_config('google_analytics', extracted)

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -30,7 +30,7 @@ class OrgExtCRUDL(OrgCRUDL):
     class Create(MakeAdminsIntoStaffMixin, OrgCRUDL.Create):
         form_class = forms.OrgExtForm
         fields = ('name', 'available_languages', 'language',
-                  'timezone', 'subdomain', 'api_token', 'show_spoof_data',
+                  'timezone', 'subdomain', 'api_token', 'google_analytics', 'show_spoof_data',
                   'logo', 'administrators')
 
     class List(OrgCRUDL.List):
@@ -39,11 +39,11 @@ class OrgExtCRUDL(OrgCRUDL):
     class Update(MakeAdminsIntoStaffMixin, OrgCRUDL.Update):
         form_class = forms.OrgExtForm
         fields = ('is_active', 'name', 'available_languages', 'language',
-                  'contact_fields', 'timezone', 'subdomain', 'api_token',
+                  'contact_fields', 'timezone', 'subdomain', 'api_token', 'google_analytics',
                   'show_spoof_data', 'logo', 'administrators')
 
     class Home(OrgCRUDL.Home):
-        fields = ('name', 'timezone', 'api_token', 'last_contact_sync',
+        fields = ('name', 'timezone', 'api_token', 'google_analytics', 'last_contact_sync',
                   'last_flow_run_fetch')
         field_config = {
             'api_token': {
@@ -52,6 +52,9 @@ class OrgExtCRUDL(OrgCRUDL):
         }
         permission = 'orgs.org_home'
         title = _("My Organization")
+
+        def get_google_analytics(self, obj):
+            return obj.get_config("google_analytics", "")
 
         def get_last_contact_sync(self, obj):
             result = obj.get_task_result(constants.TaskType.sync_contacts)

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -80,7 +80,7 @@ class OrgExtCRUDL(OrgCRUDL):
                 return None
 
     class Edit(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-        fields = ('name', 'timezone', 'contact_fields', 'logo')
+        fields = ('name', 'timezone', 'contact_fields', 'logo', 'google_analytics')
         form_class = forms.OrgExtForm
         permission = 'orgs.org_edit'
         success_url = '@orgs_ext.org_home'

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -203,6 +203,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'dash.context_processors.lang_direction',
     'tracpro.orgs_ext.context_processors.user_is_admin',
     'tracpro.orgs_ext.context_processors.available_languages',
+    'tracpro.orgs_ext.context_processors.google_analytics',
     'tracpro.groups.context_processors.show_subregions_toggle_form',
 )
 

--- a/tracpro/templates/frame.html
+++ b/tracpro/templates/frame.html
@@ -24,6 +24,20 @@
     <meta content='' name='description' />
     <meta content='' name='author' />
 
+    {% if google_analytics %}
+        <!-- Google Analytics -->
+        <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '{{ google_analytics }}', 'auto');
+        ga('send', 'pageview');
+        </script>
+        <!-- End Google Analytics -->
+    {% endif %}
+
     <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
     <!--[if lt IE 9]>
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>


### PR DESCRIPTION
Org admins can add a google analytics tracking
code to the org settings, and the org's pages
will be tracked in GA.