### PR TITLE
Skip extra groups query for new contacts

### DIFF
--- a/tracpro/contacts/signals.py
+++ b/tracpro/contacts/signals.py
@@ -42,8 +42,12 @@ def set_groups_to_new_contact(sender, instance, created, **kwargs):
     if created:
         try:
             temba_contact = get_client(instance.org).get_contacts(uuid=instance.uuid)[0]
-            # This will omit the contact's groups that are not selected to sync, but that's intentional.
-            groups = Group.objects.filter(uuid__in=temba_contact.groups)
+            if hasattr(instance, 'new_groups'):
+                # The caller already knew the groups and helpfully passed them along to us
+                groups = instance.new_groups
+            else:
+                # This will omit the contact's groups that are not selected to sync, but that's intentional.
+                groups = Group.objects.filter(uuid__in=temba_contact.groups)
             instance.groups.add(*groups)
         except IndexError:
             # The contact was created locally

--- a/tracpro/contacts/utils.py
+++ b/tracpro/contacts/utils.py
@@ -73,9 +73,12 @@ def sync_pull_contacts(org, group_uuids):
                 failed_uuids.append(temba_contact.uuid)
                 continue
 
-            new_contact = Contact.objects.create(**kwargs)
-            # Now set groups, we couldn't include them on creation
-            new_contact.groups = Group.objects.filter(uuid__in=get_uuids(temba_contact.groups))
+            # We have a signal that queries rapidpro and sets groups on new Contacts,
+            # but we already know the groups so we can skip that. This bit will let
+            # the signal handler know which groups to add without having to call Rapidpro.
+            new_contact = Contact(**kwargs)
+            new_contact.new_groups = Group.objects.filter(uuid__in=get_uuids(temba_contact.groups))
+            new_contact.save()
             created_uuids.append(kwargs['uuid'])
 
     # any contact that has been deleted from rapidpro


### PR DESCRIPTION
Signal to make fewer calls to RapidPro API and improve performance of the contact sync