### PR TITLE
Use different Redis databases for celery, cache

### DIFF
--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -10,6 +10,10 @@ from django.utils.translation import ugettext_lazy as _
 
 from .utils import *  # noqa
 
+REDIS_CELERY_BROKER_DATABASE = 1
+REDIS_CELERY_RESULTS_DATABASE = 2
+REDIS_CACHE_DATABASE = 3
+
 
 djcelery.setup_loader()
 
@@ -27,7 +31,7 @@ AUTHENTICATION_BACKENDS = (
 CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': '127.0.0.1:6379:10',
+        'LOCATION': '127.0.0.1:6379:%d' % REDIS_CACHE_DATABASE,
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
         },
@@ -230,7 +234,8 @@ USE_TZ = True
 
 ANONYMOUS_USER_ID = -1
 
-BROKER_URL = CELERY_RESULT_BACKEND = 'redis://localhost:6379/4'
+BROKER_URL = 'redis://localhost:6379/%d' % REDIS_CELERY_BROKER_DATABASE
+CELERY_RESULT_BACKEND = 'redis://localhost:6379/%d' % REDIS_CELERY_RESULTS_DATABASE
 
 CELERYD_HIJACK_ROOT_LOGGER = False
 

--- a/tracpro/settings/deploy.py
+++ b/tracpro/settings/deploy.py
@@ -13,8 +13,6 @@ WEBSERVER_ROOT = '/var/www/tracpro/'
 
 ALLOWED_HOSTS = [".{}".format(DOMAIN)]
 
-CACHES['default']['LOCATION'] = 'localhost:6379:4'
-
 CELERY_SEND_TASK_ERROR_EMAILS = True
 
 COMPRESS_CSS_HASHING_METHOD = 'content'


### PR DESCRIPTION
On deployed servers, we were putting the celery
broker, the results, and the cache all in the
same Redis database. When we cleared the cache,
we clobbered our Celery queue.

Put each one in its own database so this shouldn't
happen again.