### PR TITLE
Add some explanatory text on contact pages

### DIFF
--- a/tracpro/contacts/views.py
+++ b/tracpro/contacts/views.py
@@ -83,6 +83,7 @@ class ContactCRUDL(SmartCRUDL):
 
     class Update(OrgObjPermsMixin, ContactFormMixin, ContactBase, SmartUpdateView):
         form_class = ContactForm
+        template_name = 'contacts/contact_update.html'
 
         def post_save(self, obj):
             obj = super(ContactCRUDL.Update, self).post_save(obj)

--- a/tracpro/templates/contacts/contact_list.html
+++ b/tracpro/templates/contacts/contact_list.html
@@ -1,6 +1,15 @@
 {% extends "smartmin/list.html" %}
 {% load smartmin i18n %}
 
+{% block pre-content %}
+  {{ block.super }}
+  <div class="row">
+    <div class="col-md-12">
+        <p>{% trans "Contacts that are being tracked in TracPro. If you don't see contacts on this list, make sure that you are tracking them via the Panels and Cohorts pages." %}</p>
+    </div>
+  </div>
+{% endblock %}
+
 {% block table-controls %}
   <div class='clearfix'>
     <div class='pull-back'>

--- a/tracpro/templates/contacts/contact_update.html
+++ b/tracpro/templates/contacts/contact_update.html
@@ -1,0 +1,12 @@
+{% extends 'smartmin/update.html' %}
+{% load i18n %}
+{% block pre-content %}
+  {{ block.super }}
+  <div class="row">
+    <div class="col-md-12">
+      <p>
+        {% trans "Please note! If you edit your contact, changes will be immediately reflected in RapidPro." %}
+      </p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
New text on contacts page:
"Contacts that are being tracked in TracPro. If you don't see contacts on this list, make sure that you are tracking them via the Panels and Cohorts pages."

New text on edit contact page:
"Please note! If you edit your contact, changes will be immediately reflected in RapidPro."