### PR TITLE
Update text on flows page

### DIFF
--- a/tracpro/templates/polls/poll_list.html
+++ b/tracpro/templates/polls/poll_list.html
@@ -4,12 +4,11 @@
 {% block pre-content %}
   <div class='page-header'>
     <h2>
-      {% trans "Polls" %}
+      {% trans "Flows" %}
     </h2>
   </div>
   {% blocktrans %}
-    Each poll is a flow in RapidPro.
-
+    Latest statistics on flows that are being tracked in TracPro. Click on the 'Select Flows' button to change the flows you are tracking. All flow data is tracked going forward. If you need to track flow data for dates in the past, ask your administrator to fetch runs for those dates.
   {% endblocktrans %}
 {% endblock %}
 {% block table-buttons %}


### PR DESCRIPTION
On the page at "/poll/":

New text:
Change the wording of "Polls" -> "Flows" on this page

New description:
"Latest statistics on flows that are being tracked in TracPro. Click on the 'Select Flows' button to change the flows you are tracking. All flow data is tracked going forward. If you need to track flow data for dates in the past, ask your administrator to fetch runs for those dates."