### PR TITLE
[TD-29] infographic wizard

### DIFF
--- a/tracpro/static/less/trac.less
+++ b/tracpro/static/less/trac.less
@@ -231,7 +231,6 @@ footer {
 }
 
 .circle-label {
-
     font-size: .5em;
     color: #000000;
     line-height: 1.5em;

--- a/tracpro/static/less/trac.less
+++ b/tracpro/static/less/trac.less
@@ -204,3 +204,14 @@ footer {
 .ui-datepicker select.ui-datepicker-month, .ui-datepicker select.ui-datepicker-year {
   color: #000000;
 }
+
+/* Workflow Tracker Styles */
+.circle {
+  border-radius: 50%;
+  width: 75px;
+  height: 75px;
+  background-color: #2A5032;
+  text-align: center;
+  color: #FFFFFF;
+  font-size: 2em;
+}

--- a/tracpro/static/less/trac.less
+++ b/tracpro/static/less/trac.less
@@ -206,12 +206,42 @@ footer {
 }
 
 /* Workflow Tracker Styles */
-.circle {
+.workflow-tracker {
+  margin-left: 150px;
+  margin-bottom: 55px;
+}
+
+.circle, .circle-selected {
   border-radius: 50%;
   width: 75px;
   height: 75px;
-  background-color: #2A5032;
+  background-color: #CCC;
   text-align: center;
   color: #FFFFFF;
   font-size: 2em;
+  line-height: 2em;
+  padding-top: 0.3em;
+  &:hover {
+    background-color: #2A5032;
+  }
+}
+
+.circle-selected {
+  background-color: #2A5032;
+}
+
+.circle-label {
+
+    font-size: .5em;
+    color: #000000;
+    line-height: 1.5em;
+    padding-top: 15px;
+    width: 100px;
+    margin-left: -25px;
+}
+
+.workflow-spacer {
+  width: 100px;
+  border-top: #CCCCCC solid 1px;
+  margin-top: 40px;
 }

--- a/tracpro/static/less/trac.less
+++ b/tracpro/static/less/trac.less
@@ -219,6 +219,7 @@ footer {
   text-align: center;
   color: #FFFFFF;
   font-size: 2em;
+  font-weight: bold;
   line-height: 2em;
   padding-top: 0.3em;
   &:hover {
@@ -239,8 +240,7 @@ footer {
     margin-left: -25px;
 }
 
-.workflow-spacer {
-  width: 100px;
+.workflow-spacer, .workflow-spacer-small {
   border-top: #CCCCCC solid 1px;
   margin-top: 40px;
 }

--- a/tracpro/templates/frame.html
+++ b/tracpro/templates/frame.html
@@ -134,14 +134,14 @@
                 <li class='dropdown'>
                   <a class='dropdown-toggle' data-toggle='dropdown' href='#'>{% trans "Flow Management" %} <b class='caret'></b></a>
                   <ul class='dropdown-menu'>
-                    {% if org_perms.polls.poll_list or request.user.is_superuser or user_is_admin %}
-                      <li><a href='{% url 'polls.poll_list' %}'> {% trans "Flows" %} </a></li>
-                    {% endif %}
                     {% if org_perms.groups.region_list or request.user.is_superuser or user_is_admin %}
                       <li><a href='{% url 'groups.region_list' %}'> {% trans "Panels" %} </a></li>
                     {% endif %}
                     {% if org_perms.groups.group_list or request.user.is_superuser or user_is_admin %}
                       <li><a href='{% url 'groups.group_list' %}'> {% trans "Cohorts" %} </a></li>
+                    {% endif %}
+                    {% if org_perms.polls.poll_list or request.user.is_superuser or user_is_admin %}
+                      <li><a href='{% url 'polls.poll_list' %}'> {% trans "Flows" %} </a></li>
                     {% endif %}
                     {% if org_perms.polls.pollrun_list or request.user.is_superuser or user_is_admin %}
                       <li><a href='{% url 'polls.pollrun_list' %}'>{% trans "Flow Runs" %}</a></li>

--- a/tracpro/templates/groups/group_list.html
+++ b/tracpro/templates/groups/group_list.html
@@ -1,6 +1,12 @@
 {% extends "smartmin/list.html" %}
 {% load smartmin i18n %}
 
+
+{% block pre-content %}
+  {{ block.super }}
+  {% include 'workflow_tracker_steps.html' with step=2 %}
+{% endblock %}
+
 {% block table-controls %}
   <div class='clearfix'>
     <div class='pull-back'>

--- a/tracpro/templates/groups/region_list.html
+++ b/tracpro/templates/groups/region_list.html
@@ -30,98 +30,97 @@
   {% endcompress %}
 {% endblock extra-style %}
 
-{% block content %}
+{% block pre-content %}
+  {{ block.super }}
+  {% include 'workflow_tracker_steps.html' with step=1 %}
+{% endblock %}
 
-  {% include 'workflow_tracker_steps.html' with step='panel' %}
-
-  {% block table-controls %}
-    {% if org_perms.groups.region_select %}
-      <div id="region-actions" class="pull-right buttons">
-        <a class="btn btn-default action"
-           href="{% url 'groups.region_select' %}">
-          <span class="glyphicon glyphicon-download"></span>
-          {% trans "Select Panels" %}
-        </a>
-        <button id="edit-regions"
-                class="btn btn-default action">
-          {% trans "Edit Panels" %}
-        </button>
-        <button id="cancel-regions"
-                class="btn btn-default action hidden">
-          {% trans "Cancel Changes" %}
-        </button>
-        <button id="save-regions"
-                class="btn btn-primary action hidden">
-          {% trans "Save Panels" %}
-        </button>
-        <button id="saving-regions"
-                class="btn btn-primary disabled action hidden"
-                disabled>
-          {% trans "Saving Panels..." %}
-        </button>
-      </div>
-      <div class="clearfix"></div>
-    {% endif %}
-
-    <div>
-      <p>
-        {% blocktrans %}
-        List of Panels you track in TracPro. Panels are Groups in RapidPro. Click the "Select Panels" button to track additional RapidPro Groups.
-        {% endblocktrans %}
-      </p>
+{% block table-controls %}
+  {% if org_perms.groups.region_select %}
+    <div id="region-actions" class="pull-right buttons">
+      <a class="btn btn-default action"
+         href="{% url 'groups.region_select' %}">
+        <span class="glyphicon glyphicon-download"></span>
+        {% trans "Select Panels" %}
+      </a>
+      <button id="edit-regions"
+              class="btn btn-default action">
+        {% trans "Edit Panels" %}
+      </button>
+      <button id="cancel-regions"
+              class="btn btn-default action hidden">
+        {% trans "Cancel Changes" %}
+      </button>
+      <button id="save-regions"
+              class="btn btn-primary action hidden">
+        {% trans "Save Panels" %}
+      </button>
+      <button id="saving-regions"
+              class="btn btn-primary disabled action hidden"
+              disabled>
+        {% trans "Saving Panels..." %}
+      </button>
     </div>
-  {% endblock table-controls %}
+    <div class="clearfix"></div>
+  {% endif %}
 
-  {% block table %}
-    <table class="treetable list-table {% get_list_class object_list %} table"
-           data-update-regions-url="{% url "groups.region_update_all" %}">
-      <thead>
-        <tr>
+  <div>
+    <p>
+      {% blocktrans %}
+      List of Panels you track in TracPro. Panels are Groups in RapidPro. Click the "Select Panels" button to track additional RapidPro Groups.
+      {% endblocktrans %}
+    </p>
+  </div>
+{% endblock table-controls %}
+
+{% block table %}
+  <table class="treetable list-table {% get_list_class object_list %} table"
+         data-update-regions-url="{% url "groups.region_update_all" %}">
+    <thead>
+      <tr>
+        {% for field in fields %}
+          <th class="header-{{ field }}">{% get_label field %}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {# Something to display while treetable loads. #}
+      <tr class="loading-text">
+        <td colspan="{{ fields|length }}">Loading panels...</td>
+      </tr>
+
+      {# Include a dummy row so regions can be dragged to the top level. #}
+      <tr class="region hidden" data-tt-id="0">
+        <td colspan="{{ fields|length }}">All {{ org.name }} Panels</td>
+      </tr>
+
+      {% recursetree object_list %}
+        <tr class="region hidden" data-tt-id="{{ node.pk }}"
+            data-tt-parent-id="{% if node.is_child_node %}{{ node.parent.pk }}{% else %}0{% endif %}">
           {% for field in fields %}
-            <th class="header-{{ field }}">{% get_label field %}</th>
+            <td class="value-{{ field }}">
+              <span class="value">
+                {% get_value node field %}
+              </span>
+              {% if org_perms.groups.region_select and field == "boundary" %}
+                <select class="form-control boundary-select hidden">
+                  <option value=""{% if not node.boundary %} selected{% endif %}>
+                    -
+                  </option>
+                  {% for boundary in org_boundaries %}
+                    <option value="{{ boundary.id }}"{% if node.boundary == boundary %} selected{% endif %}>
+                      {{ boundary.name }}
+                    </option>
+                  {% endfor %}
+                </select>
+              {% endif %}
+            </td>
           {% endfor %}
         </tr>
-      </thead>
-      <tbody>
-        {# Something to display while treetable loads. #}
-        <tr class="loading-text">
-          <td colspan="{{ fields|length }}">Loading panels...</td>
-        </tr>
+        {{ children }}
+      {% endrecursetree %}
 
-        {# Include a dummy row so regions can be dragged to the top level. #}
-        <tr class="region hidden" data-tt-id="0">
-          <td colspan="{{ fields|length }}">All {{ org.name }} Panels</td>
-        </tr>
-
-        {% recursetree object_list %}
-          <tr class="region hidden" data-tt-id="{{ node.pk }}"
-              data-tt-parent-id="{% if node.is_child_node %}{{ node.parent.pk }}{% else %}0{% endif %}">
-            {% for field in fields %}
-              <td class="value-{{ field }}">
-                <span class="value">
-                  {% get_value node field %}
-                </span>
-                {% if org_perms.groups.region_select and field == "boundary" %}
-                  <select class="form-control boundary-select hidden">
-                    <option value=""{% if not node.boundary %} selected{% endif %}>
-                      -
-                    </option>
-                    {% for boundary in org_boundaries %}
-                      <option value="{{ boundary.id }}"{% if node.boundary == boundary %} selected{% endif %}>
-                        {{ boundary.name }}
-                      </option>
-                    {% endfor %}
-                  </select>
-                {% endif %}
-              </td>
-            {% endfor %}
-          </tr>
-          {{ children }}
-        {% endrecursetree %}
-
-        {% block extra-rows %}{% endblock extra-rows %}
-      </tbody>
-    </table>
-  {% endblock table %}
-
-{% endblock content %}
+      {% block extra-rows %}{% endblock extra-rows %}
+    </tbody>
+  </table>
+{% endblock table %}

--- a/tracpro/templates/groups/region_list.html
+++ b/tracpro/templates/groups/region_list.html
@@ -30,92 +30,98 @@
   {% endcompress %}
 {% endblock extra-style %}
 
-{% block table-controls %}
-  {% if org_perms.groups.region_select %}
-    <div id="region-actions" class="pull-right buttons">
-      <a class="btn btn-default action"
-         href="{% url 'groups.region_select' %}">
-        <span class="glyphicon glyphicon-download"></span>
-        {% trans "Select Panels" %}
-      </a>
-      <button id="edit-regions"
-              class="btn btn-default action">
-        {% trans "Edit Panels" %}
-      </button>
-      <button id="cancel-regions"
-              class="btn btn-default action hidden">
-        {% trans "Cancel Changes" %}
-      </button>
-      <button id="save-regions"
-              class="btn btn-primary action hidden">
-        {% trans "Save Panels" %}
-      </button>
-      <button id="saving-regions"
-              class="btn btn-primary disabled action hidden"
-              disabled>
-        {% trans "Saving Panels..." %}
-      </button>
+{% block content %}
+
+  {% include 'workflow_tracker_steps.html' with step='panel' %}
+
+  {% block table-controls %}
+    {% if org_perms.groups.region_select %}
+      <div id="region-actions" class="pull-right buttons">
+        <a class="btn btn-default action"
+           href="{% url 'groups.region_select' %}">
+          <span class="glyphicon glyphicon-download"></span>
+          {% trans "Select Panels" %}
+        </a>
+        <button id="edit-regions"
+                class="btn btn-default action">
+          {% trans "Edit Panels" %}
+        </button>
+        <button id="cancel-regions"
+                class="btn btn-default action hidden">
+          {% trans "Cancel Changes" %}
+        </button>
+        <button id="save-regions"
+                class="btn btn-primary action hidden">
+          {% trans "Save Panels" %}
+        </button>
+        <button id="saving-regions"
+                class="btn btn-primary disabled action hidden"
+                disabled>
+          {% trans "Saving Panels..." %}
+        </button>
+      </div>
+      <div class="clearfix"></div>
+    {% endif %}
+
+    <div>
+      <p>
+        {% blocktrans %}
+        List of Panels you track in TracPro. Panels are Groups in RapidPro. Click the "Select Panels" button to track additional RapidPro Groups.
+        {% endblocktrans %}
+      </p>
     </div>
-    <div class="clearfix"></div>
-  {% endif %}
+  {% endblock table-controls %}
 
-  <div>
-    <p>
-      {% blocktrans %}
-      List of Panels you track in TracPro. Panels are Groups in RapidPro. Click the "Select Panels" button to track additional RapidPro Groups.
-      {% endblocktrans %}
-    </p>
-  </div>
-{% endblock table-controls %}
-
-{% block table %}
-  <table class="treetable list-table {% get_list_class object_list %} table"
-         data-update-regions-url="{% url "groups.region_update_all" %}">
-    <thead>
-      <tr>
-        {% for field in fields %}
-          <th class="header-{{ field }}">{% get_label field %}</th>
-        {% endfor %}
-      </tr>
-    </thead>
-    <tbody>
-      {# Something to display while treetable loads. #}
-      <tr class="loading-text">
-        <td colspan="{{ fields|length }}">Loading panels...</td>
-      </tr>
-
-      {# Include a dummy row so regions can be dragged to the top level. #}
-      <tr class="region hidden" data-tt-id="0">
-        <td colspan="{{ fields|length }}">All {{ org.name }} Panels</td>
-      </tr>
-
-      {% recursetree object_list %}
-        <tr class="region hidden" data-tt-id="{{ node.pk }}"
-            data-tt-parent-id="{% if node.is_child_node %}{{ node.parent.pk }}{% else %}0{% endif %}">
+  {% block table %}
+    <table class="treetable list-table {% get_list_class object_list %} table"
+           data-update-regions-url="{% url "groups.region_update_all" %}">
+      <thead>
+        <tr>
           {% for field in fields %}
-            <td class="value-{{ field }}">
-              <span class="value">
-                {% get_value node field %}
-              </span>
-              {% if org_perms.groups.region_select and field == "boundary" %}
-                <select class="form-control boundary-select hidden">
-                  <option value=""{% if not node.boundary %} selected{% endif %}>
-                    -
-                  </option>
-                  {% for boundary in org_boundaries %}
-                    <option value="{{ boundary.id }}"{% if node.boundary == boundary %} selected{% endif %}>
-                      {{ boundary.name }}
-                    </option>
-                  {% endfor %}
-                </select>
-              {% endif %}
-            </td>
+            <th class="header-{{ field }}">{% get_label field %}</th>
           {% endfor %}
         </tr>
-        {{ children }}
-      {% endrecursetree %}
+      </thead>
+      <tbody>
+        {# Something to display while treetable loads. #}
+        <tr class="loading-text">
+          <td colspan="{{ fields|length }}">Loading panels...</td>
+        </tr>
 
-      {% block extra-rows %}{% endblock extra-rows %}
-    </tbody>
-  </table>
-{% endblock table %}
+        {# Include a dummy row so regions can be dragged to the top level. #}
+        <tr class="region hidden" data-tt-id="0">
+          <td colspan="{{ fields|length }}">All {{ org.name }} Panels</td>
+        </tr>
+
+        {% recursetree object_list %}
+          <tr class="region hidden" data-tt-id="{{ node.pk }}"
+              data-tt-parent-id="{% if node.is_child_node %}{{ node.parent.pk }}{% else %}0{% endif %}">
+            {% for field in fields %}
+              <td class="value-{{ field }}">
+                <span class="value">
+                  {% get_value node field %}
+                </span>
+                {% if org_perms.groups.region_select and field == "boundary" %}
+                  <select class="form-control boundary-select hidden">
+                    <option value=""{% if not node.boundary %} selected{% endif %}>
+                      -
+                    </option>
+                    {% for boundary in org_boundaries %}
+                      <option value="{{ boundary.id }}"{% if node.boundary == boundary %} selected{% endif %}>
+                        {{ boundary.name }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                {% endif %}
+              </td>
+            {% endfor %}
+          </tr>
+          {{ children }}
+        {% endrecursetree %}
+
+        {% block extra-rows %}{% endblock extra-rows %}
+      </tbody>
+    </table>
+  {% endblock table %}
+
+{% endblock content %}

--- a/tracpro/templates/orgs_ext/org_home.html
+++ b/tracpro/templates/orgs_ext/org_home.html
@@ -2,6 +2,14 @@
 
 {% load i18n %}
 
+{% block pre-content %}
+  {{ block.super }}
+  <div>
+    Follow these steps to start tracking your polls:<br /><br />
+  </div>
+  {% include 'workflow_tracker_steps.html' with step=0 %}
+{% endblock %}
+
 {% block read-buttons %}
   <a class="btn btn-default pull-right" href="{% url 'orgs_ext.org_edit' %}">
     <span class="glyphicon glyphicon-pencil"></span>

--- a/tracpro/templates/polls/fetch_runs.html
+++ b/tracpro/templates/polls/fetch_runs.html
@@ -1,6 +1,11 @@
 {% extends 'smartmin/form.html' %}
 {% load i18n %}
 
+{% block pre-content %}
+  {{ block.super }}
+  {% include 'workflow_tracker_steps.html' with step=4 %}
+{% endblock %}
+
 {% block pre-form %}
 
   <p>

--- a/tracpro/templates/polls/poll_list.html
+++ b/tracpro/templates/polls/poll_list.html
@@ -7,6 +7,9 @@
       {% trans "Flows" %}
     </h2>
   </div>
+
+  {% include 'workflow_tracker_steps.html' with step=3 %}
+
   {% blocktrans %}
     Latest statistics on flows that are being tracked in TracPro. Click on the 'Select Flows' button to change the flows you are tracking. All flow data is tracked going forward. If you need to track flow data for dates in the past, ask your administrator to fetch runs for those dates.
   {% endblocktrans %}

--- a/tracpro/templates/workflow_tracker_steps.html
+++ b/tracpro/templates/workflow_tracker_steps.html
@@ -1,4 +1,40 @@
-<div class="row">
-<div class="col-md-3 circle">1</div>
-<div class="col-md-3 circle">2</div>
+<div class="row workflow-tracker">
+    <a href="{% url 'groups.region_list' %}">
+        <div class="col-md-2 col-sm-1 hidden-xs {% if step == 1 %}circle-selected{% else %}circle{% endif %}">
+            1
+            <div class="circle-label">
+                Select Panels
+            </div>
+        </div>
+    </a>
+    <div class="col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+
+    <a href="{% url 'groups.group_list' %}">
+        <div class="col-md-2 col-sm-1 hidden-xs {% if step == 2 %}circle-selected{% else %}circle{% endif %}">
+            2
+            <div class="circle-label">
+                Select Cohorts
+            </div>
+        </div>
+    </a>
+    <div class="col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+
+    <a href="{% url 'polls.poll_list' %}">
+        <div class="col-md-2 col-sm-1 hidden-xs {% if step == 3 %}circle-selected{% else %}circle{% endif %}">
+            3
+            <div class="circle-label">
+                Select Flows
+            </div>
+        </div>
+    </a>
+    <div class="col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+
+    <a href="{% url 'orgs_ext.org_fetchruns' %}">
+        <div class="col-md-2 col-sm-1 hidden-xs {% if step == 4 %}circle-selected{% else %}circle{% endif %}">
+            4
+            <div class="circle-label">
+                Fetch Runs
+            </div>
+        </div>
+    </a>
 </div>

--- a/tracpro/templates/workflow_tracker_steps.html
+++ b/tracpro/templates/workflow_tracker_steps.html
@@ -1,0 +1,4 @@
+<div class="row">
+<div class="col-md-3 circle">1</div>
+<div class="col-md-3 circle">2</div>
+</div>

--- a/tracpro/templates/workflow_tracker_steps.html
+++ b/tracpro/templates/workflow_tracker_steps.html
@@ -2,37 +2,41 @@
     <a href="{% url 'groups.region_list' %}">
         <div class="col-md-2 col-sm-1 hidden-xs {% if step == 1 %}circle-selected{% else %}circle{% endif %}">
             1
-            <div class="circle-label">
+            <div class="circle-label hidden-sm hidden-xs">
                 Select Panels
             </div>
         </div>
     </a>
-    <div class="col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+    <div class="col-lg-2 col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+    <div class="hidden-lg hidden-md col-sm-1 hidden-xs workflow-spacer"></div>
+
 
     <a href="{% url 'groups.group_list' %}">
         <div class="col-md-2 col-sm-1 hidden-xs {% if step == 2 %}circle-selected{% else %}circle{% endif %}">
             2
-            <div class="circle-label">
+            <div class="circle-label hidden-sm hidden-xs">
                 Select Cohorts
             </div>
         </div>
     </a>
-    <div class="col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+    <div class="col-lg-2 col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+    <div class="hidden-lg hidden-md col-sm-1 hidden-xs workflow-spacer"></div>
 
     <a href="{% url 'polls.poll_list' %}">
         <div class="col-md-2 col-sm-1 hidden-xs {% if step == 3 %}circle-selected{% else %}circle{% endif %}">
             3
-            <div class="circle-label">
+            <div class="circle-label hidden-sm hidden-xs">
                 Select Flows
             </div>
         </div>
     </a>
-    <div class="col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+    <div class="col-lg-2 col-md-2 hidden-sm hidden-xs workflow-spacer"></div>
+    <div class="hidden-lg hidden-md col-sm-1 hidden-xs workflow-spacer"></div>
 
     <a href="{% url 'orgs_ext.org_fetchruns' %}">
         <div class="col-md-2 col-sm-1 hidden-xs {% if step == 4 %}circle-selected{% else %}circle{% endif %}">
             4
-            <div class="circle-label">
+            <div class="circle-label hidden-sm hidden-xs">
                 Fetch Runs
             </div>
         </div>


### PR DESCRIPTION
New infographic wizard on the Panel, Cohort, Poll and Fetch Run Pages

Follows UX mockup from https://caktus.atlassian.net/browse/TD-29 but the order has been changed to the above order (because you need contacts before you can track polls). The Jira ticket has been updated as well.