### PR TITLE
Redirect chooser when org known

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 	# Run all tests and report coverage
 	# Requires coverage
 	coverage erase
-	coverage run manage.py test
+	coverage run manage.py test --keepdb
 	coverage report -m --fail-under 80
 
 lint-py:
@@ -18,7 +18,7 @@ lint-py:
 lint-js:
 	# Check JS for any problems
 	# Requires jshint
-	find -name "*.js" -not -path "${STATIC_LIBS_DIR}*" -print0 | xargs -0 jshint
+	find -name "*.js" -not -path "${STATIC_LIBS_DIR}*" -a -not -path "./tracpro/static/js/*" -print0 | xargs -0 jshint
 
 lint: lint-py lint-js
 

--- a/tracpro/groups/tests/test_views.py
+++ b/tracpro/groups/tests/test_views.py
@@ -347,6 +347,14 @@ class TestRegionUpdateAll(TracProTest):
         response = self.url_get(None, reverse(self.url_name))
         self.assertRedirects(response, reverse("orgs_ext.org_chooser"))
 
+    def test_chooser_with_org(self):
+        """If org is already selected, chooser redirects to home."""
+        chooser = reverse("orgs_ext.org_chooser")
+        home = reverse('home.home')
+        response = self.url_get("test", chooser, follow=False)
+        self.assertEqual(302, response.status_code)
+        self.assertRedirects(response, home, subdomain="test", fetch_redirect_response=False)
+
     def test_no_perms(self):
         """View requires that the user is an org administrator."""
         self.org.administrators.remove(self.user)

--- a/tracpro/orgs_ext/views.py
+++ b/tracpro/orgs_ext/views.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.shortcuts import redirect
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
@@ -26,6 +28,13 @@ class MakeAdminsIntoStaffMixin(object):
 class OrgExtCRUDL(OrgCRUDL):
     actions = ('create', 'update', 'list', 'home', 'edit', 'chooser',
                'choose', 'fetchruns')
+
+    class Chooser(OrgCRUDL.Chooser):
+        def dispatch(self, request, *args, **kwargs):
+            if request.org:
+                # We have an org, no need for the chooser view
+                return redirect(reverse('home.home'))
+            return super(OrgExtCRUDL.Chooser, self).dispatch(request, *args, **kwargs)
 
     class Create(MakeAdminsIntoStaffMixin, OrgCRUDL.Create):
         form_class = forms.OrgExtForm


### PR DESCRIPTION
This fixes a longtime annoyance.

If you visit the base domain of tracpro (without the organization
prefix), you see the chooser view telling you that you need
to pick an organization.

My natural instinct is to edit the URL to stick the organization
subdomain and a dot in front of the URL and hit Enter to reload.

But before this fix, that loaded the chooser view again, which
again displayed the message that you needed to pick an
organization. At this point, that's just wrong.

This change will redirect to the site home page from the
chooser if the organization is known.