### PR TITLE
Fix tests

### DIFF
--- a/tracpro/settings/tests.py
+++ b/tracpro/settings/tests.py
@@ -18,3 +18,9 @@ PASSWORD_HASHERS = [
 ]
 
 SECRET_KEY = 'secret-key' * 5
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}


### PR DESCRIPTION
Some tests were failing if caching was configured
to use Redis (the default in the base settings) and
the system had Redis running.

Switch to the dummy cache in the test settings.