### PR TITLE
[TD-58] Fix handling when using latest answer

### DIFF
--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -137,7 +137,7 @@ class OrgExtForm(OrgForm):
             raise forms.ValidationError(_("Google analytics tracking codes start with UA-"))
         return value
 
-    def save(self, *args, **kwargs):
+    def save(self, commit=True):
         # Config field values are not set automatically.
         if 'available_languages' in self.fields:
             available_languages = self.cleaned_data.get('available_languages')
@@ -146,10 +146,10 @@ class OrgExtForm(OrgForm):
             show_spoof_data = self.cleaned_data.get('show_spoof_data')
             self.instance.show_spoof_data = show_spoof_data or False
         if 'google_analytics' in self.cleaned_data:
-            self.instance.set_config('google_analytics', self.cleaned_data.get('google_analytics'), False)
-        if 'how_to_handle_sameday_responses' in self.fields:
-            how_to_handle_sameday_responses = self.cleaned_data.get('how_to_handle_sameday_responses')
-            self.instance.how_to_handle_sameday_responses = how_to_handle_sameday_responses or SAMEDAY_LAST
+            self.instance.google_analytics = self.cleaned_data.get('google_analytics') or ''
+        if 'how_to_handle_sameday_responses' in self.cleaned_data:
+            self.instance.how_to_handle_sameday_responses = \
+                self.cleaned_data['how_to_handle_sameday_responses']
 
         if 'contact_fields' in self.fields:
             # Set hook that will be picked up by a post-save signal.
@@ -157,7 +157,7 @@ class OrgExtForm(OrgForm):
             # part of the transaction fails.
             self.instance._visible_data_fields = self.cleaned_data.get('contact_fields')
 
-        instance = super(OrgExtForm, self).save(*args, **kwargs)
+        instance = super(OrgExtForm, self).save(commit=commit)
 
         if 'how_to_handle_sameday_responses' in self.changed_data:
             # This org has changed how it handles sameday responses.

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from dash.orgs.forms import OrgForm
-from dash.orgs.models import Org
 from django.contrib.auth.models import User
 from django.db.models.functions import Lower
 

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from dash.orgs.forms import OrgForm
+from dash.orgs.models import Org
 from django.contrib.auth.models import User
 from django.db.models.functions import Lower
 
@@ -138,8 +139,6 @@ class OrgExtForm(OrgForm):
         return value
 
     def save(self, *args, **kwargs):
-        how_to_handle_was = self.instance.how_to_handle_sameday_responses
-
         # Config field values are not set automatically.
         if 'available_languages' in self.fields:
             available_languages = self.cleaned_data.get('available_languages')
@@ -161,7 +160,7 @@ class OrgExtForm(OrgForm):
 
         instance = super(OrgExtForm, self).save(*args, **kwargs)
 
-        if instance.how_to_handle_sameday_responses != how_to_handle_was:
+        if 'how_to_handle_sameday_responses' in self.changed_data:
             # This org has changed how it handles sameday responses.
             # We potentially need to update all this orgs' numeric answers.
             # This might be slow, but it's not going to need to happen

--- a/tracpro/orgs_ext/forms.py
+++ b/tracpro/orgs_ext/forms.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from tracpro.contacts.models import DataField
-from tracpro.polls.models import Answer, Question, SAMEDAY_LAST, SAMEDAY_SUM
+from tracpro.polls.models import SAMEDAY_LAST, SAMEDAY_SUM
 
 from . import utils
 
@@ -157,20 +157,7 @@ class OrgExtForm(OrgForm):
             # part of the transaction fails.
             self.instance._visible_data_fields = self.cleaned_data.get('contact_fields')
 
-        instance = super(OrgExtForm, self).save(commit=commit)
-
-        if 'how_to_handle_sameday_responses' in self.changed_data:
-            # This org has changed how it handles sameday responses.
-            # We potentially need to update all this orgs' numeric answers.
-            # This might be slow, but it's not going to need to happen
-            # very often at all.
-            for answer in Answer.objects.filter(
-                question__poll__org=instance,
-                question__question_type=Question.TYPE_NUMERIC,
-            ).distinct():
-                answer.update_own_sameday_values_and_others()
-
-        return instance
+        return super(OrgExtForm, self).save(commit=commit)
 
 
 class FetchRunsForm(forms.Form):

--- a/tracpro/orgs_ext/signals.py
+++ b/tracpro/orgs_ext/signals.py
@@ -6,6 +6,7 @@ from django.dispatch import receiver
 from dash.orgs.models import Org
 
 from tracpro.contacts.models import DataField
+from tracpro.polls.models import Answer, Question
 
 
 @receiver(post_save, sender=Org)
@@ -14,3 +15,17 @@ def set_visible_data_fields(sender, instance, **kwargs):
     if hasattr(instance, '_visible_data_fields'):
         keys = instance._visible_data_fields.values_list('key', flat=True)
         DataField.objects.set_active_for_org(instance, keys)
+
+
+@receiver(post_save, sender=Org)
+def set_value_to_use(sender, instance, **kwargs):
+    """
+    Hook to update 'value_to_use' in numeric answers based on how_to_handle_sameday_responses.
+    Unfortunately we can't do this in the form.save() method because the admin doesn't commit
+    the save until later.
+    """
+    for answer in Answer.objects.filter(
+        question__poll__org=instance,
+        question__question_type=Question.TYPE_NUMERIC,
+    ).distinct():
+        answer.update_own_sameday_values_and_others()

--- a/tracpro/orgs_ext/tests/test_forms.py
+++ b/tracpro/orgs_ext/tests/test_forms.py
@@ -173,7 +173,7 @@ class TestOrgExtForm(TracProTest):
         self.assertTrue(form.is_valid())
         form.save()
         org.refresh_from_db()
-        self.assertEqual('UA-54321', org.get_config('google_analytics'))
+        self.assertEqual('UA-54321', org.google_analytics)
 
     def test_validate_google_analytics(self, mock_sync):
         # If entered, GA code must start with "UA"
@@ -190,7 +190,7 @@ class TestOrgExtForm(TracProTest):
         self.assertTrue(form.is_valid())
         form.save()
         org.refresh_from_db()
-        self.assertEqual('', org.get_config('google_analytics'))
+        self.assertEqual('', org.google_analytics)
 
 
 class FetchRunsFormTest(TestCase):
@@ -256,6 +256,8 @@ class TestChangingHowRepeatedAnswersAreHandled(TracProDataTest):
             with mock.patch.object(Answer, 'update_own_sameday_values_and_others') as mock_update:
                 form.save()
             self.assertFalse(mock_update.call_args_list)
+            self.unicef.refresh_from_db()
+            self.assertEqual(SAMEDAY_LAST, self.unicef.how_to_handle_sameday_responses)
 
     def test_changed_last_to_sum(self):
         self.assertEqual(SAMEDAY_LAST, self.unicef.how_to_handle_sameday_responses)
@@ -276,6 +278,8 @@ class TestChangingHowRepeatedAnswersAreHandled(TracProDataTest):
             with mock.patch.object(Answer, 'update_own_sameday_values_and_others') as mock_update:
                 form.save()
             self.assertTrue(mock_update.call_args_list)
+            self.unicef.refresh_from_db()
+            self.assertEqual(SAMEDAY_SUM, self.unicef.how_to_handle_sameday_responses)
 
     def test_changed_sum_to_last(self):
         self.unicef.how_to_handle_sameday_responses = SAMEDAY_SUM
@@ -299,3 +303,5 @@ class TestChangingHowRepeatedAnswersAreHandled(TracProDataTest):
             with mock.patch.object(Answer, 'update_own_sameday_values_and_others') as mock_update:
                 form.save()
             self.assertTrue(mock_update.call_args_list)
+            self.unicef.refresh_from_db()
+            self.assertEqual(SAMEDAY_LAST, self.unicef.how_to_handle_sameday_responses)

--- a/tracpro/orgs_ext/tests/test_forms.py
+++ b/tracpro/orgs_ext/tests/test_forms.py
@@ -277,7 +277,6 @@ class TestChangingHowRepeatedAnswersAreHandled(TracProDataTest):
                 form.save()
             self.assertTrue(mock_update.call_args_list)
 
-
     def test_changed_sum_to_last(self):
         self.unicef.how_to_handle_sameday_responses = SAMEDAY_SUM
         self.unicef.save()

--- a/tracpro/orgs_ext/tests/test_forms.py
+++ b/tracpro/orgs_ext/tests/test_forms.py
@@ -276,10 +276,9 @@ class TestChangingHowRepeatedAnswersAreHandledFromLatestToSum(TracProDataTest):
             ))
             form = OrgExtForm(instance=self.unicef, data=data)
             self.assertTrue(form.is_valid(), form.errors.as_data())
-            # No change - should not try to update answers
             with mock.patch.object(Answer, 'update_own_sameday_values_and_others') as mock_update:
                 form.save()
-            self.assertFalse(mock_update.call_args_list)
+            self.assertTrue(mock_update.call_args_list)
             self.unicef.refresh_from_db()
             self.assertEqual(SAMEDAY_LAST, self.unicef.how_to_handle_sameday_responses)
             self.answer1.refresh_from_db()

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -801,11 +801,11 @@ class Answer(models.Model):
         the same day/contact/question.
         """
         answers = self.same_question_contact_and_day()
-        value = self.compute_value_to_use()
+        value_to_use = self.compute_value_to_use()
         # Update the database
-        answers.update(value_to_use=value)
+        answers.update(value_to_use=value_to_use)
         # And update this particular record in memory to avoid confusion
-        self.value_to_use = value
+        self.value_to_use = value_to_use
 
     def should_use_sum(self):
         """

--- a/tracpro/polls/tests/factories.py
+++ b/tracpro/polls/tests/factories.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import datetime
 import json
 
 from dateutil.relativedelta import relativedelta

--- a/tracpro/polls/tests/factories.py
+++ b/tracpro/polls/tests/factories.py
@@ -112,9 +112,9 @@ class Response(factory.django.DjangoModelFactory):
     flow_run_id = factory.Sequence(lambda n: n)
     pollrun = factory.SubFactory('tracpro.test.factories.PollRun')
     contact = factory.SubFactory('tracpro.test.factories.Contact')
-    created_on = factory.fuzzy.FuzzyDate(
-        start_date=datetime.date.today() - relativedelta(days=7),
-        end_date=datetime.date.today())
+    created_on = factory.fuzzy.FuzzyDateTime(
+        start_dt=now() - relativedelta(days=7),
+        end_dt=now())
     updated_on = factory.LazyAttribute(lambda o: o.created_on)
     status = factory.fuzzy.FuzzyChoice(c[0] for c in models.Response.STATUS_CHOICES)
 

--- a/tracpro/polls/tests/test_models.py
+++ b/tracpro/polls/tests/test_models.py
@@ -674,27 +674,35 @@ class TestAnswer(TracProDataTest):
     def test_create(self):
         pollrun = factories.UniversalPollRun(
             poll=self.poll1, conducted_on=timezone.now())
-        response = Response.create_empty(
+        response1 = Response.create_empty(
             self.unicef, pollrun,
             Run.create(id=123, contact='C-001', created_on=timezone.now()))
 
         answer1 = factories.Answer(
-            response=response, question=self.poll1_question1,
+            response=response1, question=self.poll1_question1,
             value="4.00000", category="1 - 5")
-        self.assertEqual(answer1.response, response)
+        self.assertEqual(answer1.response, response1)
         self.assertEqual(answer1.question, self.poll1_question1)
         self.assertEqual(answer1.category, "1 - 5")
         self.assertEqual(answer1.value, "4.00000")
         self.assertEqual(answer1.value_to_use, "4.00000")
 
+        response2 = Response.create_empty(
+            self.unicef, pollrun,
+            Run.create(id=124, contact='C-002', created_on=timezone.now()))
+
         answer2 = factories.Answer(
-            response=response, question=self.poll1_question1,
+            response=response2, question=self.poll1_question1,
             value="rain", category=dict(base="Rain", rwa="Imvura"))
         self.assertEqual(answer2.category, "Rain")
         self.assertEqual(answer2.value_to_use, "rain")
 
+        response3 = Response.create_empty(
+            self.unicef, pollrun,
+            Run.create(id=125, contact='C-003', created_on=timezone.now()))
+
         answer3 = factories.Answer(
-            response=response, question=self.poll1_question1,
+            response=response3, question=self.poll1_question1,
             value="rain", category=dict(eng="Yes"))
         self.assertEqual(answer3.category, "Yes")
         self.assertEqual(answer3.value_to_use, "rain")

--- a/tracpro/polls/tests/test_models.py
+++ b/tracpro/polls/tests/test_models.py
@@ -10,11 +10,13 @@ import pytz
 
 from unittest import skip
 
+from django.utils.timezone import now
 from temba_client.v2.types import Run
 
 from django.db import IntegrityError
 from django.utils import timezone
 
+from tracpro.polls.models import SAMEDAY_LAST
 from tracpro.test import factories
 from tracpro.test.cases import TracProTest, TracProDataTest
 
@@ -483,7 +485,7 @@ class PollRunTest(TracProDataTest):
             Run.create(id=123, contact='C-001', created_on=timezone.now()))
         factories.Answer(
             response=response1, question=self.poll1_question1,
-            value="4.00000", category="1 - 5")
+            value=str(4.0), category="1 - 5")
         factories.Answer(
             response=response1, question=self.poll1_question2,
             value="It's very rainy", category="All Responses")
@@ -493,7 +495,7 @@ class PollRunTest(TracProDataTest):
             Run.create(id=234, contact='C-002', created_on=timezone.now()))
         factories.Answer(
             response=response2, question=self.poll1_question1,
-            value="3.00000", category="1 - 5")
+            value=str(3.0), category="1 - 5")
         factories.Answer(
             response=response2, question=self.poll1_question2,
             value="rainy and rainy", category="All Responses")
@@ -503,7 +505,7 @@ class PollRunTest(TracProDataTest):
             Run.create(id=345, contact='C-004', created_on=timezone.now()))
         factories.Answer(
             response=response3, question=self.poll1_question1,
-            value="8.00000", category="6 - 10")
+            value=str(8.0), category="6 - 10")
         factories.Answer(
             response=response3, question=self.poll1_question2,
             value="Sunny sunny", category="All Responses")
@@ -530,13 +532,13 @@ class TestResponse(TracProDataTest):
                 Run.Value.create(
                     category="1 - 50",
                     node='RS-001',
-                    value="6.00000000",
+                    value=str(6.0),
                     time=datetime.datetime(2014, 1, 2, 3, 4, 5, 6, pytz.UTC)
                 ),
                 Run.Value.create(
                     category="1 - 25",
                     node='RS-002',
-                    value="4.00000000",
+                    value=str(4.0),
                     time=datetime.datetime(2015, 1, 2, 3, 4, 5, 6, pytz.UTC),
                 ),
             ],
@@ -556,13 +558,13 @@ class TestResponse(TracProDataTest):
 
         answers = list(response1.answers.order_by('question_id'))
         self.assertEqual(answers[0].question, self.poll1_question1)
-        self.assertEqual(answers[0].value, "6.00000000")
+        self.assertEqual(answers[0].value, str(6.0))
         self.assertEqual(answers[0].category, "1 - 50")
         self.assertEqual(
             answers[0].submitted_on,
             datetime.datetime(2014, 1, 2, 3, 4, 5, 6, pytz.UTC))
         self.assertEqual(answers[1].question, self.poll1_question2)
-        self.assertEqual(answers[1].value, "4.00000000")
+        self.assertEqual(answers[1].value, str(4.0))
         self.assertEqual(answers[1].category, "1 - 25")
         self.assertEqual(
             answers[1].submitted_on,
@@ -578,7 +580,7 @@ class TestResponse(TracProDataTest):
                 Run.Value.create(
                     category="1 - 50",
                     node='RS-001',
-                    value="6.00000000",
+                    value=str(6.0),
                     time=datetime.datetime(2014, 1, 2, 3, 4, 5, 6, pytz.UTC),
                 ),
             ],
@@ -606,13 +608,13 @@ class TestResponse(TracProDataTest):
                 Run.Value.create(
                     category="1 - 50",
                     node='RS-001',
-                    value="6.00000000",
+                    value=str(6.0),
                     time=datetime.datetime(2014, 1, 2, 3, 4, 5, 6, pytz.UTC),
                 ),
                 Run.Value.create(
                     category="1 - 25",
                     node='RS-002',
-                    value="4.00000000",
+                    value=str(4.0),
                     time=datetime.datetime(2015, 1, 2, 3, 4, 5, 6, pytz.UTC),
                 ),
             ],
@@ -680,12 +682,12 @@ class TestAnswer(TracProDataTest):
 
         answer1 = factories.Answer(
             response=response1, question=self.poll1_question1,
-            value="4.00000", category="1 - 5")
+            value=str(4.0), category="1 - 5")
         self.assertEqual(answer1.response, response1)
         self.assertEqual(answer1.question, self.poll1_question1)
         self.assertEqual(answer1.category, "1 - 5")
-        self.assertEqual(answer1.value, "4.00000")
-        self.assertEqual(answer1.value_to_use, "4.00000")
+        self.assertEqual(answer1.value, str(4.0))
+        self.assertEqual(answer1.value_to_use, str(4.0))
 
         response2 = Response.create_empty(
             self.unicef, pollrun,
@@ -707,6 +709,35 @@ class TestAnswer(TracProDataTest):
         self.assertEqual(answer3.category, "Yes")
         self.assertEqual(answer3.value_to_use, "rain")
 
+    def test_same_question_contact_and_day(self):
+        poll = self.poll1_question1.poll
+        response1 = factories.Response(pollrun__poll=poll)
+        answer1 = factories.Answer(
+            response=response1,
+            question=self.poll1_question1,
+            value=str(4.0),
+            category="1 - 5",
+            submitted_on=now() - datetime.timedelta(minutes=5),
+        )
+
+        response2 = factories.Response(pollrun__poll=poll, contact=response1.contact)
+        answer2 = factories.Answer(
+            response=response2,
+            question=self.poll1_question1,
+            submitted_on=now() - datetime.timedelta(minutes=2),
+        )
+
+        response3 = factories.Response(pollrun__poll=poll, contact=response1.contact)
+        answer3 = factories.Answer(
+            response=response3,
+            question=self.poll1_question1,
+            submitted_on=now(),
+        )
+
+        self.assertEqual(3, len(answer1.same_question_contact_and_day()))
+        self.assertEqual(3, len(answer2.same_question_contact_and_day()))
+        self.assertEqual(3, len(answer3.same_question_contact_and_day()))
+
 
 class TestAnswerSumming(TracProDataTest):
     how_to_handle_sameday_responses = SAMEDAY_SUM
@@ -714,30 +745,84 @@ class TestAnswerSumming(TracProDataTest):
     def test_create_with_summing(self):
         pollrun = factories.UniversalPollRun(
             poll=self.poll1, conducted_on=timezone.now())
-        response = Response.create_empty(
-            self.unicef, pollrun,
-            Run.create(id=123, contact='C-001', created_on=timezone.now()))
+        response = factories.Response(pollrun=pollrun)
 
         answer1 = factories.Answer(
             response=response, question=self.poll1_question1,
-            value="4.00000", category="1 - 5")
-        self.assertEqual(answer1.value, "4.00000")  # untouched
-        self.assertEqual(answer1.value_to_use, "4.000000")
+            value=str(4.0), category="1 - 5")
+        self.assertEqual(answer1.value, str(4.0))  # untouched
+        self.assertEqual(answer1.value_to_use, str(4.0))
 
         # Another response, same contact
-        response2 = Response.create_empty(
-            self.unicef, pollrun,
-            Run.create(id=124, contact='C-001', created_on=timezone.now()))
+        response2 = factories.Response(pollrun=pollrun, contact=response.contact)
         answer2 = factories.Answer(
             response=response2,
             question=self.poll1_question1,  # same question
-            value="8.000",  # new value
+            value=str(8.0),  # new value
             submitted_on=answer1.submitted_on,  # same day (exactly!)
         )
-        self.assertEqual(answer2.value, "8.000")
-        self.assertEqual(answer2.value_to_use, "12.000000")
+        self.assertEqual(answer2.value, str(8.0))
+        self.assertEqual(answer2.value_to_use, str(12.0))
         answer1.refresh_from_db()  # This should have been updated in the DB
-        self.assertEqual(answer1.value_to_use, "12.000000")
+        self.assertEqual(answer1.value_to_use, str(12.0))
+
+    def test_phone_numbers_not_summed(self):
+        # Really this is testing error handling, since "phone numbers" aren't "numbers"
+        # and shouldn't be in numeric questions' answers anyway.
+        pollrun = factories.UniversalPollRun(
+            poll=self.poll1, conducted_on=timezone.now())
+        response = factories.Response(pollrun=pollrun)
+
+        answer1 = factories.Answer(
+            response=response, question=self.poll1_question1,
+            value="444-5555", category="1 - 5")
+        self.assertEqual(answer1.value, "444-5555")  # untouched
+        self.assertEqual(answer1.value_to_use, "444-5555")
+
+        # Another response, same contact
+        response2 = factories.Response(pollrun=pollrun, contact=response.contact)
+        answer2 = factories.Answer(
+            response=response2,
+            question=self.poll1_question1,  # same question
+            value="555-1212",  # new value
+            submitted_on=answer1.submitted_on,  # same day (exactly!)
+        )
+        self.assertEqual(answer2.value, "555-1212")
+        self.assertEqual(answer2.value_to_use, "555-1212")
+        answer1.refresh_from_db()
+        self.assertEqual(answer1.value_to_use, "444-5555")
+
+    def test_last_answer(self):
+        pollrun = factories.UniversalPollRun(
+            poll=self.poll1, conducted_on=timezone.now())
+        pollrun.poll.org.how_to_handle_sameday_responses = SAMEDAY_LAST
+        pollrun.poll.org.save()
+        response = factories.Response(
+            pollrun=pollrun
+        )
+        answer1 = factories.Answer(
+            response=response, question=self.poll1_question1,
+            value=str(4.0),
+            submitted_on=now() - datetime.timedelta(minutes=5),
+            category="1 - 5")
+        self.assertEqual(answer1.value, str(4.0))  # untouched
+        self.assertEqual(answer1.value_to_use, str(4.0))
+
+        # Another response, same contact
+        response2 = factories.Response(
+            pollrun=pollrun,
+            contact=response.contact
+        )
+        answer2 = factories.Answer(
+            response=response2,
+            question=self.poll1_question1,  # same question
+            value=str(8.0),  # new value
+            submitted_on=now(),
+        )
+        self.assertEqual(answer2.value, str(8.0))
+        self.assertEqual(answer2.value_to_use, str(8.0))
+        answer1.refresh_from_db()  # This should have been updated in the DB
+        self.assertEqual(answer1.value_to_use, str(8.0))
 
 
 class TestAnswerQuerySet(TracProDataTest):
@@ -763,7 +848,7 @@ class TestAnswerQuerySet(TracProDataTest):
             response__pollrun=self.pollrun,
             response__status=models.Response.STATUS_COMPLETE,
             question=self.question1,
-            value="4.00000",
+            value=str(4.0),
             category="numeric")
 
         factories.Answer(
@@ -772,7 +857,7 @@ class TestAnswerQuerySet(TracProDataTest):
             response__pollrun=self.pollrun,
             response__status=models.Response.STATUS_COMPLETE,
             question=self.question1,
-            value="3.00000",
+            value=str(3.0),
             category="numeric")
 
         factories.Answer(
@@ -781,7 +866,7 @@ class TestAnswerQuerySet(TracProDataTest):
             response__pollrun=self.pollrun,
             response__status=models.Response.STATUS_COMPLETE,
             question=self.question1,
-            value="8.00000", category="numeric")
+            value=str(8.0), category="numeric")
 
     def test_autocategorize(self):
         # autocategorize breaks down numeric results into categories
@@ -811,7 +896,7 @@ class TestAnswerQuerySet(TracProDataTest):
             response__pollrun=self.pollrun,
             response__status=models.Response.STATUS_COMPLETE,
             question=self.question1,
-            value="10.2",
+            value=str(10.2),
             category="foo")
 
         # We skip any non-numeric response, even if category is 'numeric'


### PR DESCRIPTION
Need to set all answers' "value_to_use" to the latest
answer on that day, if the org is configured that way;
apparently cannot rely on charts just using the answer
from the latest response. (?)