### PR TITLE
Handle starting a run with many contacts

### DIFF
--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -32,6 +32,13 @@ from .utils import sync_pull_contacts
 logger = logging.getLogger(__name__)
 
 
+class NoContactInRapidProWarning(Exception):
+    """
+    Raised when we try to get a remote contact and it doesn't exist.
+    """
+    pass
+
+
 class NoMatchingCohortsWarning(Exception):
     """
     Have Contact.kwargs_from_temba be a little more specific about this case by
@@ -188,11 +195,12 @@ class Contact(models.Model):
             return contacts.get(uuid=uuid)
         except cls.DoesNotExist:
             # If this contact does not exist locally, we need to call the RapidPro API to get it
-            try:
-                temba_contact = get_client(org).get_contacts(uuid=uuid)[0]
-                return cls.objects.create(**cls.kwargs_from_temba(org, temba_contact))
-            except IndexError:
-                return None
+            temba_contacts = get_client(org).get_contacts(uuid=uuid)
+            if not temba_contacts:
+                # Probably shouldn't happen - but does
+                raise NoContactInRapidProWarning("No contact in RapidPro with uuid=%s" % uuid)
+            temba_contact = temba_contacts[0]
+            return cls.objects.create(**cls.kwargs_from_temba(org, temba_contact))
 
     def get_responses(self, include_empty=True):
         from tracpro.polls.models import Response

--- a/tracpro/polls/models.py
+++ b/tracpro/polls/models.py
@@ -17,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from tracpro.charts.utils import midnight, end_of_day
 from tracpro.client import get_client
-from tracpro.contacts.models import Contact, NoMatchingCohortsWarning
+from tracpro.contacts.models import Contact, NoMatchingCohortsWarning, NoContactInRapidProWarning
 
 from . import rules
 from .tasks import pollrun_start
@@ -591,7 +591,7 @@ class Response(models.Model):
 
         try:
             contact = Contact.get_or_fetch(poll.org, uuid=run.contact.uuid)
-        except NoMatchingCohortsWarning as e:
+        except (NoMatchingCohortsWarning, NoContactInRapidProWarning) as e:
             # Callers expect a ValueError if we don't sync the response
             raise ValueError("not syncing run because %s" % e.args[0])
 

--- a/tracpro/polls/tasks.py
+++ b/tracpro/polls/tasks.py
@@ -90,8 +90,15 @@ def pollrun_start(pollrun_id):
         contacts = contacts.filter(region=pollrun.region)
     contact_uuids = list(contacts.values_list('uuid', flat=True))
 
-    runs = client.create_flow_start(
-        flow=pollrun.poll.flow_uuid, urns=None, contacts=contact_uuids, restart_participants=True)
+    runs = []
+    # There's a limit of 100 contacts per call to create_flow_start (why?)
+    while len(contact_uuids):
+        runs.extend(
+            client.create_flow_start(
+                flow=pollrun.poll.flow_uuid, urns=None, contacts=contact_uuids[:100],
+                restart_participants=True)
+        )
+        contact_uuids = contact_uuids[100:]
 
     for run in runs:
         Response.create_empty(org, pollrun, run)


### PR DESCRIPTION
Saw an error on production due to starting a run when
there were more than 100 contacts - there's an arbitrary
limit in the API of 100 contacts.

Fix by looping until we've started runs for all the contacts.