### PR TITLE
Allow forcing syncs when debugging

### DIFF
--- a/tracpro/contacts/models.py
+++ b/tracpro/contacts/models.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime
+import traceback
 from decimal import Decimal, InvalidOperation
 import logging
 from uuid import uuid4
@@ -65,7 +66,7 @@ class ContactManager(models.Manager.from_queryset(ContactQuerySet)):
             region_uuids = set(get_uuids(Region.get_all(org)))
             group_uuids = set(get_uuids(Group.get_all(org)))
 
-            created, updated, deleted, failed = sync_pull_contacts(
+            created, updated, deleted, failed, errors = sync_pull_contacts(
                 org=org,
                 region_uuids=region_uuids,
                 group_uuids=group_uuids
@@ -82,6 +83,8 @@ class ContactManager(models.Manager.from_queryset(ContactQuerySet)):
             })
         except:
             logger.exception("EXCEPTION in ContactManager.sync")
+            return [traceback.format_exc()]
+        return errors
 
 
 @python_2_unicode_compatible

--- a/tracpro/contacts/urls.py
+++ b/tracpro/contacts/urls.py
@@ -1,5 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
-from .views import ContactCRUDL
+from django.conf.urls import url
+
+from tracpro.utils import is_production
+from .views import ContactCRUDL, force_contacts_sync
 
 urlpatterns = ContactCRUDL().as_urlpatterns()
+
+if not is_production():
+    urlpatterns += [
+        url(r'^force_contacts_sync/$', force_contacts_sync, name='force_contacts_sync'),
+    ]

--- a/tracpro/contacts/utils.py
+++ b/tracpro/contacts/utils.py
@@ -21,7 +21,8 @@ def sync_pull_contacts(org, region_uuids, group_uuids):
 
     :param org: the org
     :param group_uuidss: the contact group UUIDs used - used to determine if local contact differs
-    :return: tuple containing list of UUIDs for created, updated, deleted and failed contacts
+    :return: tuple containing list of UUIDs for created, updated, deleted and failed contacts,
+     and error/warning messages
     """
     from tracpro.contacts.models import Contact, NoMatchingCohortsWarning
     from tracpro.groups.models import Group, Region
@@ -38,6 +39,7 @@ def sync_pull_contacts(org, region_uuids, group_uuids):
     updated_uuids = []
     deleted_uuids = []
     failed_uuids = []
+    errors = []
 
     total_contacts = 0
     for temba_contact in incoming_contacts:
@@ -65,6 +67,7 @@ def sync_pull_contacts(org, region_uuids, group_uuids):
             except NoMatchingCohortsWarning as e:
                 logger.warning(e.message)
                 failed_uuids.append(temba_contact.uuid)
+                errors.append(e.message)
                 continue
 
             for field, value in six.iteritems(kwargs):
@@ -87,6 +90,7 @@ def sync_pull_contacts(org, region_uuids, group_uuids):
             except NoMatchingCohortsWarning as e:
                 logger.warning(e.message)
                 failed_uuids.append(temba_contact.uuid)
+                errors.append(e.message)
                 continue
 
             msg = "%d Adding NEW contact: %s" % (total_contacts, temba_contact.name)
@@ -120,7 +124,8 @@ def sync_pull_contacts(org, region_uuids, group_uuids):
     return (list(set(created_uuids)),
             list(set(updated_uuids)),
             list(set(deleted_uuids)),
-            list(set(failed_uuids)))
+            list(set(failed_uuids)),
+            errors)
 
 
 def temba_compare_contacts(first, second, fields=None, groups=None):

--- a/tracpro/contacts/views.py
+++ b/tracpro/contacts/views.py
@@ -6,8 +6,10 @@ import pycountry
 
 from dash.orgs.views import OrgPermsMixin, OrgObjPermsMixin
 from dash.utils import get_obj_cacheable
+from django.contrib import messages
 
 from django.http import JsonResponse
+from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 
 from smartmin.views import (
@@ -181,3 +183,15 @@ class ContactCRUDL(SmartCRUDL):
     class Delete(OrgObjPermsMixin, ContactBase, SmartDeleteView):
         cancel_url = '@contacts.contact_list'
         redirect_url = '@contacts.contact_list'
+
+
+def force_contacts_sync(request):
+    if not request.user.is_superuser:
+        return redirect('home.home')
+    errors = Contact.objects.sync(request.org)
+    if errors:
+        for err in errors:
+            messages.error(request, err)
+    else:
+        messages.info(request, 'Contacts synced, apparently okay')
+    return redirect('home.home')

--- a/tracpro/orgs_ext/context_processors.py
+++ b/tracpro/orgs_ext/context_processors.py
@@ -3,6 +3,13 @@ from __future__ import unicode_literals
 from django.conf import settings
 
 from tracpro.orgs_ext.utils import is_supervisor
+from tracpro.utils import is_production
+
+
+def deploy_is_production(request):
+    return {
+        'is_production': is_production(),
+    }
 
 
 def user_is_admin(request):

--- a/tracpro/polls/urls.py
+++ b/tracpro/polls/urls.py
@@ -1,7 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
-from .views import PollCRUDL, PollRunCRUDL, ResponseCRUDL
+from django.conf.urls import url
+
+from tracpro.utils import is_production
+from .views import PollCRUDL, PollRunCRUDL, ResponseCRUDL, force_runs_sync
 
 urlpatterns = PollCRUDL().as_urlpatterns()
 urlpatterns += PollRunCRUDL().as_urlpatterns()
 urlpatterns += ResponseCRUDL().as_urlpatterns()
+
+if not is_production():
+    urlpatterns += [
+        url(r'^force_runs_sync/$', force_runs_sync, name='force_runs_sync'),
+    ]

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -20,6 +20,7 @@ from smartmin.templatetags.smartmin import format_datetime
 
 from tracpro.contacts.models import Contact
 from tracpro.groups.models import Group, Region
+from tracpro.polls.tasks import FetchOrgRuns
 
 from . import charts, forms, maps, tasks
 from .models import Poll, Question, PollRun, Response
@@ -683,3 +684,16 @@ class ResponseCRUDL(smartmin.SmartCRUDL):
             context = super(ResponseCRUDL.ByContact, self).get_context_data(**kwargs)
             context['contact'] = self.derive_contact()
             return context
+
+
+def force_runs_sync(request):
+    if not request.user.is_superuser:
+        return redirect('home.home')
+    fetcher = FetchOrgRuns()
+    errors = fetcher.org_task(request.org)
+    if errors:
+        for err in errors:
+            messages.error(request, err)
+    else:
+        messages.info(request, "Runs appear to have been fetched okay")
+    return redirect('home.home')

--- a/tracpro/settings/base.py
+++ b/tracpro/settings/base.py
@@ -205,6 +205,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'dash.orgs.context_processors.user_group_perms_processor',
     'dash.orgs.context_processors.set_org_processor',
     'dash.context_processors.lang_direction',
+    'tracpro.orgs_ext.context_processors.deploy_is_production',
     'tracpro.orgs_ext.context_processors.user_is_admin',
     'tracpro.orgs_ext.context_processors.available_languages',
     'tracpro.orgs_ext.context_processors.google_analytics',

--- a/tracpro/templates/frame.html
+++ b/tracpro/templates/frame.html
@@ -125,6 +125,10 @@
                   <ul class='dropdown-menu'>
                     <li><a href='{% url 'orgs_ext.org_list' %}'> {% trans "Organizations" %} </a></li>
                     <li><a href='{% url 'profiles.admin_list' %}'> {% trans "Users" %} </a></li>
+                    {% if not is_production %}
+                      <li><a href='{% url 'force_contacts_sync' %}'>Force contacts sync</a></li>
+                      <li><a href='{% url 'force_runs_sync' %}'>Force runs sync</a></li>
+                    {% endif %}
                   </ul>
                 </li>
               {% endif %}

--- a/tracpro/utils.py
+++ b/tracpro/utils.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+
+
 def get_uuids(things):
     """
     Return an iterable of the 'uuid' attribute values of the things.
@@ -5,3 +8,7 @@ def get_uuids(things):
     The things can be anything with a 'uuid' attribute.
     """
     return [thing.uuid for thing in things]
+
+
+def is_production():
+    return hasattr(settings, 'ENVIRONMENT') and settings.ENVIRONMENT.endswith('production')


### PR DESCRIPTION
For superusers when not deployed to production,
add a couple menu items under "site management"
to allow forcing contact and flow run syncs at
any time.