### PR TITLE
Be quieter when we try to delete a contact that's not on RapidPro

### DIFF
--- a/tracpro/contacts/utils.py
+++ b/tracpro/contacts/utils.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import six
 
 from celery.utils.log import get_task_logger
+from temba_client.base import TembaNoSuchObjectError
 
 from temba_client.clients import TembaBadRequestError
 
@@ -227,6 +228,9 @@ def sync_push_contact(org, contact, change_type):
     elif change_type == ChangeType.deleted:
         try:
             client.delete_contact(contact.uuid)
+        except TembaNoSuchObjectError:
+            # Nothing to do, it's already gone (or was never there)
+            pass
         except TembaBadRequestError as e:
             temba_err_msg = ''
             for key, value in e.errors.iteritems():


### PR DESCRIPTION
Don't log an error if user deletes a contact, we try
to delete it on RapidPro, and get back an error that
there's no such contact there. We've got what we wanted -
that contact isn't on RapidPro.