### PR TITLE
[TD-67] Include all responses as-is in CSV downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint-py:
 lint-js:
 	# Check JS for any problems
 	# Requires jshint
-	find -name "*.js" -not -path "${STATIC_LIBS_DIR}*" -a -not -path "./tracpro/static/js/*" -print0 | xargs -0 jshint
+	find -name "*.js" -not -path "${STATIC_LIBS_DIR}*" -a -not -path "./tracpro/static/js/*" -a -not -path "./public/*" -print0 | xargs -0 jshint
 
 lint: lint-py lint-js
 

--- a/tracpro/polls/tests/test_views.py
+++ b/tracpro/polls/tests/test_views.py
@@ -147,7 +147,7 @@ class ResponseCRUDLTest(TracProDataTest):
 
         rows = [[element.decode('utf-8') for element in row]
                 for row in csv.reader(StringIO(response.content.decode('utf-8')))]
-        self.assertEqual(rows[0], ['Date', 'Name', 'URN', 'Panel', 'Cohort', 'Number of sheep', 'How is the weather?'])
+        self.assertEqual(rows[0], ['Date', 'Name', 'URN', 'Panel', 'Cohorts', 'Number of sheep', 'How is the weather?'])
         self.assertEqual(rows[1], [
                                     'Jan 01, 2014 12:30',
                                     'Bob',

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -601,7 +601,7 @@ class ResponseCRUDL(smartmin.SmartCRUDL):
                 questions = self.derive_questions().values()
 
                 resp_headers = ['Date']
-                contact_headers = ['Name', 'URN', 'Panel', 'Cohort']
+                contact_headers = ['Name', 'URN', 'Panel', 'Cohorts']
                 question_headers = [q.name for q in questions]
                 writer.writerow(resp_headers + contact_headers + question_headers)
 


### PR DESCRIPTION
When we show charts of responses, we pretend each contact only
responded once to the poll each day, either taking the last response
or the sum of their responses for the day.

When downloading CSV, we instead want to include all the
responses, exactly as they were answered.