### PR TITLE
Improve view performance for multiple answers

### DIFF
--- a/tracpro/polls/charts.py
+++ b/tracpro/polls/charts.py
@@ -87,7 +87,9 @@ def multiple_pollruns(pollruns, responses, question, split_regions, contact_filt
     summary_table = None
 
     pollruns = pollruns.order_by('conducted_on')
-    answers = Answer.objects.filter(response__in=responses, question=question)
+    answers = Answer.objects.\
+        filter(response__in=responses, question=question).\
+        select_related('question__poll__org', 'response__contact')
 
     # Save a bit of time with .exists();
     # queryset is re-evaluated later as a values set.

--- a/tracpro/polls/maps.py
+++ b/tracpro/polls/maps.py
@@ -56,11 +56,13 @@ def numeric_map_data(answers, question):
     ]
 
     for boundary_id, _answers in groupby(answer_data, itemgetter('boundary')):
-        average = round(numpy.mean(get_numeric_values(a['value_to_use'] for a in _answers)), 2)
-        map_data[boundary_id] = {
-            'average': format_number(average, digits=2),
-            'category': question.categorize(average),
-        }
+        values = get_numeric_values(a['value_to_use'] for a in _answers)
+        if len(values) > 0:
+            average = round(numpy.mean(values), 2)
+            map_data[boundary_id] = {
+                'average': format_number(average, digits=2),
+                'category': question.categorize(average),
+            }
     return map_data
 
 

--- a/tracpro/polls/migrations/0038_compute_values_for_multiple_answers.py
+++ b/tracpro/polls/migrations/0038_compute_values_for_multiple_answers.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from tracpro.polls.utils import get_numeric_values
+
+
 """
 WARNING: THIS MIGRATION WILL TAKE A LONG TIME FOR REAL DATA.
+
+(As of early December 2017, there are nearly a
+million Answers in the database.)
 
 Suggestions to speed it up any more would be welcome.
 Maybe some SQL ninja can come up with a SQL statement
@@ -17,9 +23,6 @@ from django.db.models import F
 from tracpro.charts.utils import midnight, end_of_day
 
 
-TYPE_NUMERIC = 'N'
-
-
 def compute_values_0038(apps, schema):
     Answer = apps.get_model('polls.Answer')
 
@@ -31,25 +34,33 @@ def compute_values_0038(apps, schema):
     print("There are %d answers to look at." % count)
 
     # Some need to be updated.
-    # We ONLY need to update the 'active' ones though - those are the only ones that
-    # are actually looked at when we build charts and tables.
-    for answer in Answer.objects.filter(question__question_type=TYPE_NUMERIC, response__is_active=True).select_related('response'):
+    # For each active numeric answer, if there were other answers to the same question on
+    # the same day by the same contact, then update all of them.
+    # Try it for non-numeric questions too - someday they could change to numeric and
+    # otherwise we would not have values to use for them.
+    for answer in Answer.objects.filter(response__is_active=True).select_related('response'):
         # All answers by same contact for same question on same day
         answers = Answer.objects.filter(
             question_id=answer.question_id,
             response__contact_id=answer.response.contact_id,
             submitted_on__gte=midnight(answer.submitted_on),
             submitted_on__lte=end_of_day(answer.submitted_on),
-        )
+        ).order_by('-submitted_on')
         if len(answers) > 1:
             # There was more than one answer by same contact/day/question.
             # Compute last and sum.
-            answer.last_value = answers.order_by('-submitted_on')[0].value
-            try:
-                answer.sum_value = str(sum([float(a.value) for a in answers]))
-            except ValueError:
-                answer.sum_value = answer.value  # Just use record's value
-            answer.save()
+            as_floats = get_numeric_values([a.value for a in answers])
+            if len(as_floats) > 0:
+                sum_value = str(sum(as_floats))
+            else:
+                sum_value = F('value')  # No valid floats, just use value as-is
+            last_value = answers[0].value
+            answers.update(last_value=last_value, sum_value=sum_value)
+
+
+def undo_values_0038(apps, schema):
+    Answer = apps.get_model('polls.Answer')
+    Answer.objects.update(last_value=None, sum_value=None)
 
 
 class Migration(migrations.Migration):
@@ -59,5 +70,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(compute_values_0038, migrations.RunPython.noop),
+        migrations.RunPython(
+            compute_values_0038,
+            undo_values_0038
+        )
     ]

--- a/tracpro/polls/utils.py
+++ b/tracpro/polls/utils.py
@@ -108,19 +108,3 @@ def overall_stdev(pollruns, data, default=0, round_to=1):
     """Return the standard deviation of data values for each pollrun."""
     padded_data = [data.get(pollrun.pk, default) for pollrun in pollruns]
     return round(numpy.std(padded_data), round_to)
-
-
-def just_floats(values):
-    """
-    Convert the values to floats and return them as a list, skipping any that
-    don't convert successfully.
-    """
-    result = []
-    for value in values:
-        try:
-            f = float(value)
-        except ValueError:
-            pass
-        else:
-            result.append(f)
-    return result

--- a/tracpro/polls/views.py
+++ b/tracpro/polls/views.py
@@ -503,7 +503,6 @@ class ResponseCRUDL(smartmin.SmartCRUDL):
             def fetch():
                 questions = OrderedDict()
                 for question in self.derive_pollrun().poll.questions.prefetch_related('answers').active():
-                    setattr(question, 'first_answer', question.answers.all()[0])
                     questions['question_%d' % question.pk] = question
                 return questions
 
@@ -540,7 +539,10 @@ class ResponseCRUDL(smartmin.SmartCRUDL):
             if field == 'region':
                 return obj.contact.region
             elif field == 'groups':
-                return ', '.join(group.name.encode('utf-8') for group in obj.contact.groups.all().order_by('name'))
+                # obj is a Response
+                groups = obj.contact.groups  # This can be pre-fetched, avoiding a query per row
+                group_names = [group.name for group in groups.all()]  # then sort in Python, the list is small
+                return u', '.join(sorted(group_names))
             elif field.startswith('question_'):
                 question = self.derive_questions()[field]
                 answer = obj.answers.filter(question=question).first()


### PR DESCRIPTION
* Reduce queries with select_related and prefetch_related
* Take care not to unnecessarily trigger re-evaluation of queries

Other changes:

* Pre-compute for *all* answers in case some questions not currently
  set as "numeric" get changed to that later
* Found that just_floats method duplicated another existing one,
  so just use that one.
* Fix a bug in maps when the values weren't all valid numbers