### PR TITLE
Rapidpro API change broke tracpro

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ pycountry==1.10
 python-dateutil==2.5.1
 pytz==2016.2
 rapidpro-dash==1.1
-rapidpro-python==2.1.5
+rapidpro-python==2.2
 requests==2.9.1
 six==1.10.0
 smartmin==1.10.5


### PR DESCRIPTION
Rapidpro started returning a non-integer version
field in flow definitions, which caused an exception
when trying to fetch flow definitions using the
official Python client for RapidPro until we upgraded
it.

Unfortunately this has probably resulted in synced
responses that have no answers, which will not be
fixed even by fetching past runs again. This fix does
not address that, but should make future syncs worka
again.