### PR TITLE
Fix bug responding to a conversation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ cache:
 env:
   - DJANGO_SETTINGS_MODULE="tracpro.settings.tests"
 install:
+  - psql --version
+  - echo "select version();" | psql
   - pip install --upgrade pip
   - pip install -r requirements/tests.txt
   - npm install less

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ cache:
 env:
   - DJANGO_SETTINGS_MODULE="tracpro.settings.tests"
 install:
-  - psql --version
-  - echo "select version();" | psql
   - pip install --upgrade pip
   - pip install -r requirements/tests.txt
   - npm install less

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ enum34==1.1.2
 numpy==1.12.0
 phonenumbers==8.5.1
 pisa==3.0.33
-psycopg2==2.6.1
+psycopg2==2.7
 pycountry==1.10
 python-dateutil==2.5.1
 pytz==2016.2

--- a/tracpro/msgs/tests/test_views.py
+++ b/tracpro/msgs/tests/test_views.py
@@ -99,11 +99,7 @@ class InboxMessageCRUDLTest(TracProDataTest):
 
         # Post a short message as a response.
         response = self.url_post('unicef', url, data={'text': 'Now is the time'}, follow=True)
-        self.assertRedirects(
-            response,
-            reverse('msgs.inboxmessage_conversation', kwargs=dict(contact_id=self.contact1.pk)),
-            subdomain='unicef'
-        )
+        self.assertRedirects(response, url, subdomain='unicef')
         # We did try to send it to Rapidpro
         self.assertTrue(self.mock_temba_client.create_broadcast.call_count)
 

--- a/tracpro/msgs/views.py
+++ b/tracpro/msgs/views.py
@@ -166,6 +166,8 @@ class InboxMessageCRUDL(SmartCRUDL):
             return context
 
         def post(self, request, *args, **kwargs):
+            # Call get_queryset to populate the view instance's data
+            self.get_queryset()
             if self.form.is_valid():
                 # Send the new inbox message through the temba task
                 send_unsolicited_message(self.request.org, request.POST.get('text'), self.contact)


### PR DESCRIPTION
Fix a bug reported by Shane when trying to respond to a conversation.

First added a test and made sure it reproduced the problem, then fixed the problem so the test passed.

Also, make a change to double-check that Travis is giving us the postgres version we asked for, which I added before determining the real problem was that psycopg2 needed to be upgraded to fix a bug parsing postgres versions.